### PR TITLE
fix: harden mail recipient delivery and persistence

### DIFF
--- a/src/main/java/com/joaorihan/courierprime/command/PostCommand.java
+++ b/src/main/java/com/joaorihan/courierprime/command/PostCommand.java
@@ -10,7 +10,6 @@ import org.bukkit.util.StringUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class PostCommand extends AbstractCommand{
 
@@ -53,11 +52,16 @@ public class PostCommand extends AbstractCommand{
         }
 
         // Command exec
-        List<String> recipients = Arrays.stream(args)
-                .flatMap(argument -> Arrays.stream(argument.split(",")))
-                .map(String::trim)
-                .filter(recipient -> !recipient.isEmpty())
-                .collect(Collectors.toList());
+        List<String> recipients = new ArrayList<>();
+        for (String argument : args) {
+            if (argument == null) {
+                continue;
+            }
+            recipients.addAll(Arrays.stream(argument.split("[,\\s]+"))
+                    .map(String::trim)
+                    .filter(recipient -> !recipient.isEmpty())
+                    .toList());
+        }
 
         if (recipients.isEmpty()) {
             player.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));

--- a/src/main/java/com/joaorihan/courierprime/letter/LetterSender.java
+++ b/src/main/java/com/joaorihan/courierprime/letter/LetterSender.java
@@ -1,19 +1,30 @@
 package com.joaorihan.courierprime.letter;
 
-import com.joaorihan.courierprime.config.MessageManager;
-import org.apache.commons.text.WordUtils;
-import org.bukkit.inventory.meta.BookMeta;
 import com.joaorihan.courierprime.CourierPrime;
-import com.joaorihan.courierprime.config.Message;
-import com.joaorihan.courierprime.courier.Courier;
 import com.joaorihan.courierprime.config.MainConfig;
-import org.bukkit.*;
+import com.joaorihan.courierprime.config.Message;
+import com.joaorihan.courierprime.config.MessageManager;
+import com.joaorihan.courierprime.courier.Courier;
+import org.apache.commons.text.WordUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Send the letters to players
@@ -27,8 +38,8 @@ public class LetterSender {
 
 
     public LetterSender(CourierPrime plugin){
-         this.plugin = plugin;
-         this.messageManager = plugin.getMessageManager();
+        this.plugin = plugin;
+        this.messageManager = plugin.getMessageManager();
     }
 
 
@@ -41,56 +52,101 @@ public class LetterSender {
      * @param recipient player(s) to receive the letter
      */
     public void send(Player sender, String recipient) {
-        if (LetterUtil.isHoldingOwnLetter(sender) &&
-                !LetterUtil.wasAlreadySent(sender.getInventory().getItemInMainHand())) {
+        if (!canSendOwnLetter(sender)) {
+            return;
+        }
 
-            ItemStack letter = sender.getInventory().getItemInMainHand();
-            List<String> lore = createLetterLore(letter);
+        List<String> recipients = splitRecipients(recipient);
+        if (recipients.size() > 1) {
+            send(sender, recipients.toArray(new String[0]));
+            return;
+        }
 
-            Collection<OfflinePlayer> offlinePlayers;
+        String requestedRecipient = recipients.isEmpty() ? recipient : recipients.get(0);
+        Collection<OfflinePlayer> offlinePlayers;
+        Message successMessage;
+        List<String> lore = createLetterLore(sender.getInventory().getItemInMainHand());
 
-            switch (recipient) {
-                case "*":
-                    offlinePlayers = handleAllOnline(sender, lore);
-                    break;
-                case "**":
-                    offlinePlayers = handleAll(sender, lore);
-                    break;
-                default:
-                    offlinePlayers = handleSingleRecipient(sender, recipient, lore);
+        if ("*".equals(requestedRecipient)) {
+            offlinePlayers = handleAllOnline(sender);
+            if (offlinePlayers == null || offlinePlayers.isEmpty()) {
+                return;
             }
-
-            if (offlinePlayers != null && !offlinePlayers.isEmpty()) {
-                sendLettersToPlayers(sender, letter, lore, offlinePlayers, true);
+            lore.add(messageManager.getMessage(Message.LETTER_TO_ALLONLINE));
+            successMessage = Message.SUCCESS_SENT_ALLONLINE;
+        } else if ("**".equals(requestedRecipient)) {
+            offlinePlayers = handleAll(sender);
+            if (offlinePlayers == null || offlinePlayers.isEmpty()) {
+                return;
             }
-
+            lore.add(messageManager.getMessage(Message.LETTER_TO_ALL));
+            successMessage = Message.SUCCESS_SENT_ALL;
         } else {
-            handleLetterErrors(sender);
+            if (!sender.hasPermission("courierprime.post.one")) {
+                sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
+                return;
+            }
+
+            OfflinePlayer offlinePlayer = resolveRecipient(sender, requestedRecipient);
+            if (offlinePlayer == null) {
+                return;
+            }
+
+            offlinePlayers = Collections.singletonList(offlinePlayer);
+            lore.add(messageManager.getMessage(Message.LETTER_TO_ONE)
+                    .replace("$PLAYER$", offlinePlayer.getName()));
+            successMessage = Message.SUCCESS_SENT_ONE;
+        }
+
+        ItemStack letter = sender.getInventory().getItemInMainHand();
+        if (sendLettersToPlayers(sender, letter, lore, offlinePlayers, true, false)) {
+            String success = messageManager.getMessage(successMessage, true);
+            if (successMessage == Message.SUCCESS_SENT_ONE) {
+                success = success.replace("$PLAYER$", offlinePlayers.iterator().next().getName());
+            }
+            sender.sendMessage(success);
         }
     }
 
 
     public void send(Player sender, String[] recipients) {
-        if (LetterUtil.isHoldingOwnLetter(sender) &&
-                !LetterUtil.wasAlreadySent(sender.getInventory().getItemInMainHand())) {
+        if (!canSendOwnLetter(sender)) {
+            return;
+        }
 
-            ItemStack letter = sender.getInventory().getItemInMainHand();
-            List<String> lore = createLetterLore(letter);
+        List<String> requestedRecipients = splitRecipients(recipients);
+        if (requestedRecipients.isEmpty()) {
+            sender.sendMessage(messageManager.getMessage(Message.ERROR_UNKNOWN_ARGS, true));
+            return;
+        }
 
-            Collection<OfflinePlayer> offlinePlayers;
+        if (!sender.hasPermission("courierprime.post.multiple")) {
+            sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
+            return;
+        }
 
-            offlinePlayers = handleMultipleRecipients(sender, recipients, lore);
+        Collection<OfflinePlayer> offlinePlayers = handleMultipleRecipients(sender, requestedRecipients);
+        if (offlinePlayers == null || offlinePlayers.isEmpty()) {
+            return;
+        }
 
-            if (offlinePlayers != null && !offlinePlayers.isEmpty()) {
-                sendLettersToPlayers(sender, letter, lore, offlinePlayers, true);
-            }
+        ItemStack letter = sender.getInventory().getItemInMainHand();
+        List<String> lore = createLetterLore(letter);
+        lore.add(messageManager.getMessage(Message.LETTER_TO_MULTIPLE));
 
-        } else {
-            handleLetterErrors(sender);
+        if (sendLettersToPlayers(sender, letter, lore, offlinePlayers, true, false)) {
+            sender.sendMessage(messageManager.getMessage(Message.SUCCESS_SENT_MULTIPLE, true));
         }
     }
 
     public void forward(Player sender, String recipient) {
+        if (sender == null || !sender.hasPermission("courierprime.forward")) {
+            if (sender != null) {
+                sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
+            }
+            return;
+        }
+
         if (!LetterUtil.isHoldingLetter(sender)){
             sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_LETTER));
             return;
@@ -103,22 +159,20 @@ public class LetterSender {
             return;
         }
 
-        BookMeta letterMeta = (BookMeta) letter.getItemMeta();
-        letterMeta.setGeneration(BookMeta.Generation.COPY_OF_ORIGINAL);
-        letter.setItemMeta(letterMeta);
-
-        List<String> lore = createLetterLore(letter);
-
-        lore.add("");
-        lore.add(messageManager.getMessage(Message.LETTER_FORWARDED_BY).replace("$PLAYER$", sender.getName()));
-
-        var offlinePlayerRecipient = handleSingleRecipient(sender, recipient, lore);
-
-        if (offlinePlayerRecipient == null || offlinePlayerRecipient.isEmpty()){
+        OfflinePlayer offlinePlayer = resolveRecipient(sender, recipient);
+        if (offlinePlayer == null) {
             return;
         }
 
-        sendLettersToPlayers(sender, letter, lore, offlinePlayerRecipient, false);
+        List<String> lore = createLetterLore(letter);
+        lore.add("");
+        lore.add(messageManager.getMessage(Message.LETTER_FORWARDED_BY)
+                .replace("$PLAYER$", sender.getName()));
+
+        // The source item is only changed by sendLettersToPlayers after validation,
+        // queue insertion, and persistence have succeeded. A failed lookup therefore
+        // cannot change its generation or lore.
+        sendLettersToPlayers(sender, letter, lore, Collections.singletonList(offlinePlayer), false, true);
     }
 
     private List<String> createLetterLore(ItemStack letter) {
@@ -129,6 +183,9 @@ public class LetterSender {
 
         BookMeta letterMeta = (BookMeta) letter.getItemMeta();
         String firstPage = letterMeta.getPageCount() > 0 ? letterMeta.getPage(1) : "";
+        if (firstPage == null) {
+            firstPage = "";
+        }
         String wrapped = WordUtils.wrap(MessageManager.unformat(firstPage), 30, "<split>", true);
         String[] lines = wrapped.split("<split>");
         lore.add("");
@@ -142,68 +199,44 @@ public class LetterSender {
         return lore;
     }
 
-    private Collection<OfflinePlayer> handleAllOnline(Player sender, List<String> lore) {
-        if (sender.hasPermission("courierprime.post.allonline")) {
-            lore.add("§T" + Message.LETTER_TO_ALLONLINE);
-            Collection<OfflinePlayer> onlinePlayers = new ArrayList<>(Bukkit.getOnlinePlayers());
-            sender.sendMessage(messageManager.getMessage(Message.SUCCESS_SENT_ALLONLINE, true));
-            return onlinePlayers;
-        } else {
+    private Collection<OfflinePlayer> handleAllOnline(Player sender) {
+        if (!sender.hasPermission("courierprime.post.allonline")) {
             sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
             return null;
         }
+
+        Map<UUID, OfflinePlayer> onlinePlayers = new LinkedHashMap<>();
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            addUsableRecipient(onlinePlayers, onlinePlayer);
+        }
+        return onlinePlayers.values();
     }
 
-    private Collection<OfflinePlayer> handleAll(Player sender, List<String> lore) {
-        if (sender.hasPermission("courierprime.post.all")) {
-            lore.add("§T" + Message.LETTER_TO_ALL);
-            Collection<OfflinePlayer> allPlayers = new ArrayList<>(Arrays.asList(Bukkit.getOfflinePlayers()));
-            sender.sendMessage(messageManager.getMessage(Message.SUCCESS_SENT_ALL, true));
-            return allPlayers;
-        } else {
+    private Collection<OfflinePlayer> handleAll(Player sender) {
+        if (!sender.hasPermission("courierprime.post.all")) {
             sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
             return null;
         }
+
+        Map<UUID, OfflinePlayer> allPlayers = new LinkedHashMap<>();
+        for (OfflinePlayer offlinePlayer : Arrays.asList(Bukkit.getOfflinePlayers())) {
+            addUsableRecipient(allPlayers, offlinePlayer);
+        }
+        return allPlayers.values();
     }
 
-    private Collection<OfflinePlayer> handleMultipleRecipients(Player sender, String[] recipients, List<String> lore) {
-        if (sender.hasPermission("courierprime.post.multiple")) {
-            Set<OfflinePlayer> offlinePlayers = new LinkedHashSet<>();
+    private Collection<OfflinePlayer> handleMultipleRecipients(Player sender, List<String> recipients) {
+        Map<UUID, OfflinePlayer> offlinePlayers = new LinkedHashMap<>();
 
-            for (String recipient : recipients) {
-                OfflinePlayer op = resolveRecipient(sender, recipient);
-                if (op == null) {
-                    return null;
-                }
-                offlinePlayers.add(op);
-            }
-
-            if (offlinePlayers.isEmpty()) {
+        for (String recipient : recipients) {
+            OfflinePlayer offlinePlayer = resolveRecipient(sender, recipient);
+            if (offlinePlayer == null) {
                 return null;
             }
-
-            lore.add("§T" + messageManager.getMessage(Message.LETTER_TO_MULTIPLE));
-            sender.sendMessage(messageManager.getMessage(Message.SUCCESS_SENT_MULTIPLE, true));
-            return offlinePlayers;
-        } else {
-            sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
-            return null;
+            addUsableRecipient(offlinePlayers, offlinePlayer);
         }
-    }
 
-    private Collection<OfflinePlayer> handleSingleRecipient(Player sender, String recipient, List<String> lore) {
-        if (sender.hasPermission("courierprime.post.one")) {
-            OfflinePlayer op = resolveRecipient(sender, recipient);
-            if (op == null) {
-                return null;
-            }
-            lore.add("§T" + messageManager.getMessage(Message.LETTER_TO_ONE).replace("$PLAYER$", op.getName()));
-            sender.sendMessage(messageManager.getMessage(Message.SUCCESS_SENT_ONE, true).replace("$PLAYER$", op.getName()));
-            return Collections.singletonList(op);
-        } else {
-            sender.sendMessage(messageManager.getMessage(Message.ERROR_NO_PERMS, true));
-            return null;
-        }
+        return offlinePlayers.values();
     }
 
     private OfflinePlayer resolveRecipient(Player sender, String name) {
@@ -214,42 +247,231 @@ public class LetterSender {
             return null;
         }
 
-        OfflinePlayer player = Bukkit.getOfflinePlayer(trimmedName);
-        if (player.getName() == null || (!player.isOnline() && !player.hasPlayedBefore())) {
-            sender.sendMessage(messageManager.getMessage(Message.ERROR_PLAYER_NO_EXIST, true)
-                    .replace("$PLAYER$", trimmedName));
-            return null;
+        try {
+            // Resolve online players first so a current player is never treated as a
+            // synthetic offline profile created by getOfflinePlayer(String).
+            Player onlinePlayer = Bukkit.getPlayer(trimmedName);
+            if (onlinePlayer != null && hasUsableName(onlinePlayer.getName()) && onlinePlayer.getUniqueId() != null) {
+                return onlinePlayer;
+            }
+
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(trimmedName);
+            if (offlinePlayer != null
+                    && hasUsableName(offlinePlayer.getName())
+                    && offlinePlayer.getUniqueId() != null
+                    && (offlinePlayer.isOnline() || offlinePlayer.hasPlayedBefore())) {
+                return offlinePlayer;
+            }
+        } catch (RuntimeException ignored) {
+            // Treat malformed or unsupported lookups as an unknown player. The sender
+            // still receives the normal user-facing error below.
         }
-        return player;
+
+        sender.sendMessage(messageManager.getMessage(Message.ERROR_PLAYER_NO_EXIST, true)
+                .replace("$PLAYER$", trimmedName));
+        return null;
     }
 
-    private void sendLettersToPlayers(Player sender, ItemStack letter, List<String> lore, Collection<OfflinePlayer> offlinePlayers, boolean shouldRemoveItem) {
-        BookMeta letterMeta = (BookMeta) letter.getItemMeta();
-        letterMeta.setLore(lore);
-        letter.setItemMeta(letterMeta);
+    private boolean hasUsableName(String name) {
+        return name != null && !name.trim().isEmpty();
+    }
 
-        for (OfflinePlayer op : offlinePlayers) {
-            if (offlinePlayers.size() > 1 && op.equals(sender)) continue;
+    private void addUsableRecipient(Map<UUID, OfflinePlayer> recipients, OfflinePlayer recipient) {
+        if (recipient == null || recipient.getUniqueId() == null || !hasUsableName(recipient.getName())) {
+            return;
+        }
+        try {
+            if (!recipient.isOnline() && !recipient.hasPlayedBefore()) {
+                return;
+            }
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        recipients.putIfAbsent(recipient.getUniqueId(), recipient);
+    }
 
-            plugin.getOutgoingManager().getOutgoing().computeIfAbsent(op.getUniqueId(), k -> new LinkedList<>()).add(new ItemStack(letter));
+    private boolean sendLettersToPlayers(Player sender,
+                                         ItemStack letter,
+                                         List<String> lore,
+                                         Collection<OfflinePlayer> offlinePlayers,
+                                         boolean shouldRemoveItem,
+                                         boolean shouldMarkAsForwarded) {
+        ItemStack preparedLetter;
+        ItemStack sourceSnapshot;
+        try {
+            preparedLetter = letter.clone();
+            sourceSnapshot = letter.clone();
+            if (!(preparedLetter.getItemMeta() instanceof BookMeta letterMeta)) {
+                return false;
+            }
+            if (shouldMarkAsForwarded) {
+                letterMeta.setGeneration(BookMeta.Generation.COPY_OF_ORIGINAL);
+            }
+            letterMeta.setLore(new ArrayList<>(lore));
+            preparedLetter.setItemMeta(letterMeta);
+        } catch (RuntimeException exception) {
+            plugin.getLogger().warning("Unable to prepare outgoing letter: " + exception.getMessage());
+            return false;
+        }
 
-            Player onlineRecipient = op.getPlayer();
-            if (onlineRecipient != null && onlineRecipient.isOnline()) {
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        if (onlineRecipient.isOnline()) {
-                            new Courier(onlineRecipient);
-                        }
-                    }
-                }.runTaskLater(CourierPrime.getPlugin(), MainConfig.getReceiveDelay());
+        Map<UUID, List<ItemStack>> pendingLetters = new LinkedHashMap<>();
+        List<OfflinePlayer> queuedRecipients = new ArrayList<>();
+        boolean skipSender = offlinePlayers.size() > 1;
+        UUID senderUuid = sender.getUniqueId();
+
+        for (OfflinePlayer offlinePlayer : offlinePlayers) {
+            if (offlinePlayer == null || offlinePlayer.getUniqueId() == null) {
+                continue;
+            }
+            if (skipSender && senderUuid != null && senderUuid.equals(offlinePlayer.getUniqueId())) {
+                continue;
+            }
+
+            // Clone once per recipient so no recipient can mutate another recipient's
+            // BookMeta or ItemStack through a shared object reference.
+            pendingLetters.computeIfAbsent(offlinePlayer.getUniqueId(), ignored -> new ArrayList<>())
+                    .add(preparedLetter.clone());
+            queuedRecipients.add(offlinePlayer);
+        }
+
+        if (pendingLetters.isEmpty()) {
+            return false;
+        }
+
+        OutgoingManager outgoingManager = plugin.getOutgoingManager();
+        HashMap<UUID, LinkedList<ItemStack>> outgoing = outgoingManager.getOutgoing();
+        Map<UUID, Integer> originalSizes = new LinkedHashMap<>();
+
+        synchronized (outgoing) {
+            try {
+                for (Map.Entry<UUID, List<ItemStack>> entry : pendingLetters.entrySet()) {
+                    LinkedList<ItemStack> letters = outgoing.computeIfAbsent(entry.getKey(), ignored -> new LinkedList<>());
+                    originalSizes.put(entry.getKey(), letters.size());
+                    letters.addAll(entry.getValue());
+                }
+
+                // Persist the queue before changing the source item. A failed lookup
+                // or queue operation therefore leaves the held item untouched.
+                outgoingManager.saveAll();
+
+                BookMeta sourceMeta = (BookMeta) letter.getItemMeta();
+                sourceMeta.setLore(new ArrayList<>(lore));
+                if (shouldMarkAsForwarded) {
+                    sourceMeta.setGeneration(BookMeta.Generation.COPY_OF_ORIGINAL);
+                }
+                letter.setItemMeta(sourceMeta);
+                if (shouldRemoveItem) {
+                    letter.setAmount(0);
+                }
+            } catch (RuntimeException exception) {
+                rollbackQueuedLetters(outgoing, pendingLetters, originalSizes);
+                try {
+                    outgoingManager.saveAll();
+                } catch (RuntimeException ignored) {
+                    // Preserve the original failure in the log; the in-memory queue
+                    // has still been rolled back as far as the map permits.
+                }
+                try {
+                    letter.setItemMeta(sourceSnapshot.getItemMeta());
+                    letter.setAmount(sourceSnapshot.getAmount());
+                } catch (RuntimeException ignored) {
+                    // The source was already a valid BookMeta item; if a host inventory
+                    // rejects restoration, retain the original queue failure evidence.
+                }
+                plugin.getLogger().warning("Unable to queue outgoing letters: " + exception.getMessage());
+                return false;
             }
         }
 
-        plugin.getOutgoingManager().saveAll();
+        for (OfflinePlayer offlinePlayer : queuedRecipients) {
+            scheduleDelivery(offlinePlayer);
+        }
+        return true;
+    }
 
-        if (shouldRemoveItem)
-            sender.getInventory().getItemInMainHand().setAmount(0);
+    private void rollbackQueuedLetters(HashMap<UUID, LinkedList<ItemStack>> outgoing,
+                                       Map<UUID, List<ItemStack>> pendingLetters,
+                                       Map<UUID, Integer> originalSizes) {
+        for (Map.Entry<UUID, List<ItemStack>> entry : pendingLetters.entrySet()) {
+            LinkedList<ItemStack> letters = outgoing.get(entry.getKey());
+            if (letters == null) {
+                continue;
+            }
+
+            int originalSize = originalSizes.getOrDefault(entry.getKey(), 0);
+            while (letters.size() > originalSize) {
+                letters.removeLast();
+            }
+            if (letters.isEmpty() && originalSize == 0) {
+                outgoing.remove(entry.getKey());
+            }
+        }
+    }
+
+    private void scheduleDelivery(OfflinePlayer offlinePlayer) {
+        Player onlineRecipient;
+        try {
+            onlineRecipient = offlinePlayer.getPlayer();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        if (onlineRecipient == null || !onlineRecipient.isOnline()) {
+            return;
+        }
+
+        try {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (onlineRecipient.isOnline()) {
+                        new Courier(onlineRecipient);
+                    }
+                }
+            }.runTaskLater(plugin, MainConfig.getReceiveDelay());
+        } catch (RuntimeException exception) {
+            plugin.getLogger().warning("Unable to schedule mail delivery for "
+                    + offlinePlayer.getName() + ": " + exception.getMessage());
+        }
+    }
+
+    private boolean canSendOwnLetter(Player sender) {
+        if (sender != null
+                && LetterUtil.isHoldingOwnLetter(sender)
+                && !LetterUtil.wasAlreadySent(sender.getInventory().getItemInMainHand())) {
+            return true;
+        }
+
+        if (sender != null) {
+            handleLetterErrors(sender);
+        }
+        return false;
+    }
+
+    private List<String> splitRecipients(String recipient) {
+        if (recipient == null) {
+            return Collections.emptyList();
+        }
+        return splitRecipients(new String[]{recipient});
+    }
+
+    private List<String> splitRecipients(String[] recipients) {
+        List<String> tokens = new ArrayList<>();
+        if (recipients == null) {
+            return tokens;
+        }
+
+        for (String recipient : recipients) {
+            if (recipient == null) {
+                continue;
+            }
+            for (String token : recipient.split("[,\\s]+")) {
+                String trimmed = token.trim();
+                if (!trimmed.isEmpty()) {
+                    tokens.add(trimmed);
+                }
+            }
+        }
+        return tokens;
     }
 
     private void handleLetterErrors(Player sender) {
@@ -262,7 +484,7 @@ public class LetterSender {
         }
     }
 
-    
+
     /**
      * When clicking the courier, retrieve the letters from the file and give all of them to the player. If they have
      * space in their inventory, give them all, starting with their hand if they aren't holding anything. Letters not
@@ -271,31 +493,125 @@ public class LetterSender {
      * @param recipient player receiving the mail
      */
     public void receive(Player recipient) {
-        if (plugin.getOutgoingManager().hasPendingLetters(recipient)) {
-            LinkedList<ItemStack> letters = plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId());
+        if (recipient == null) {
+            return;
+        }
 
-            while (!letters.isEmpty()) {
-                ItemStack letter = letters.pop();
-                if (recipient.getInventory().getItemInMainHand().getAmount() == 0) {
-                    recipient.getInventory().setItemInMainHand(letter);
-                } else if (recipient.getInventory().firstEmpty() < 0) {
-                    letters.push(letter);
-                    recipient.sendMessage(messageManager.getMessage(Message.ERROR_CANT_HOLD, true));
-                    break;
-                } else {
-                    Map<Integer, ItemStack> leftovers = recipient.getInventory().addItem(letter);
-                    if (!leftovers.isEmpty()) {
-                        letters.push(letter);
-                        recipient.sendMessage(messageManager.getMessage(Message.ERROR_CANT_HOLD, true));
+        OutgoingManager outgoingManager = plugin.getOutgoingManager();
+        HashMap<UUID, LinkedList<ItemStack>> outgoing = outgoingManager.getOutgoing();
+        boolean hadPendingLetters = false;
+
+        synchronized (outgoing) {
+            LinkedList<ItemStack> letters = outgoing.get(recipient.getUniqueId());
+            if (letters != null && !letters.isEmpty()) {
+                hadPendingLetters = true;
+                boolean inventoryFull = false;
+
+                while (!letters.isEmpty()) {
+                    ItemStack letter = letters.pollFirst();
+                    if (letter == null) {
+                        plugin.getLogger().warning("Ignoring null pending outgoing item for " + recipient.getUniqueId());
+                        continue;
+                    }
+
+                    ItemStack queuedCopy;
+                    try {
+                        queuedCopy = letter.clone();
+                        if (queuedCopy.getType() == null || queuedCopy.getType().isAir() || queuedCopy.getAmount() <= 0) {
+                            plugin.getLogger().warning("Ignoring malformed pending outgoing item for " + recipient.getUniqueId());
+                            continue;
+                        }
+                    } catch (RuntimeException exception) {
+                        plugin.getLogger().warning("Ignoring malformed pending outgoing item for "
+                                + recipient.getUniqueId() + ": " + exception.getMessage());
+                        continue;
+                    }
+
+                    ItemStack hand = recipient.getInventory().getItemInMainHand();
+                    boolean handEmpty = hand == null || hand.getType() == null || hand.getType().isAir()
+                            || hand.getAmount() <= 0;
+
+                    if (handEmpty) {
+                        try {
+                            recipient.getInventory().setItemInMainHand(queuedCopy);
+                            continue;
+                        } catch (RuntimeException exception) {
+                            letters.addFirst(queuedCopy);
+                            plugin.getLogger().warning("Unable to place pending outgoing item in the recipient's hand: "
+                                    + exception.getMessage());
+                            inventoryFull = true;
+                            break;
+                        }
+                    }
+
+                    if (recipient.getInventory().firstEmpty() < 0) {
+                        letters.addFirst(queuedCopy);
+                        inventoryFull = true;
+                        break;
+                    }
+
+                    try {
+                        ItemStack deliveryAttempt = queuedCopy.clone();
+                        Map<Integer, ItemStack> leftovers = recipient.getInventory().addItem(deliveryAttempt);
+                        if (leftovers != null && !leftovers.isEmpty()) {
+                            requeueLeftovers(letters, queuedCopy, leftovers);
+                            inventoryFull = true;
+                            break;
+                        }
+                    } catch (RuntimeException exception) {
+                        letters.addFirst(queuedCopy);
+                        plugin.getLogger().warning("Unable to deliver pending outgoing item for "
+                                + recipient.getUniqueId() + ": " + exception.getMessage());
+                        inventoryFull = true;
                         break;
                     }
                 }
+
+                if (inventoryFull) {
+                    recipient.sendMessage(messageManager.getMessage(Message.ERROR_CANT_HOLD, true));
+                }
+
+                if (letters.isEmpty()) {
+                    outgoing.remove(recipient.getUniqueId());
+                }
             }
-            
-            recipient.updateInventory();
-            plugin.getOutgoingManager().saveAll();
+
+            if (hadPendingLetters) {
+                recipient.updateInventory();
+            }
+            outgoingManager.saveAll();
         }
     }
-    
+
+    private void requeueLeftovers(LinkedList<ItemStack> letters,
+                                  ItemStack original,
+                                  Map<Integer, ItemStack> leftovers) {
+        List<ItemStack> undelivered = new ArrayList<>();
+        for (ItemStack leftover : leftovers.values()) {
+            if (leftover == null) {
+                continue;
+            }
+            try {
+                if (leftover.getType() == null || leftover.getType().isAir() || leftover.getAmount() <= 0) {
+                    continue;
+                }
+                undelivered.add(leftover.clone());
+            } catch (RuntimeException ignored) {
+                // A malformed leftover is not safe to put back into the queue.
+            }
+        }
+
+        if (undelivered.isEmpty()) {
+            // A compliant Bukkit inventory returns the undelivered stack. If a custom
+            // inventory violates that contract, retain the original rather than lose
+            // the mail; this path is only used when no usable leftover was returned.
+            letters.addFirst(original.clone());
+            return;
+        }
+
+        for (int index = undelivered.size() - 1; index >= 0; index--) {
+            letters.addFirst(undelivered.get(index));
+        }
+    }
 
 }

--- a/src/main/java/com/joaorihan/courierprime/letter/OutgoingManager.java
+++ b/src/main/java/com/joaorihan/courierprime/letter/OutgoingManager.java
@@ -6,7 +6,9 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -19,15 +21,17 @@ import java.util.UUID;
 public class OutgoingManager {
 
     @Getter
-    private HashMap<UUID, LinkedList<ItemStack>> outgoing;
+    private final HashMap<UUID, LinkedList<ItemStack>> outgoing;
 
     /**
      * reference to outgoing config
      */
     private final YamlConfiguration outgoingConfig;
+    private final CourierPrime plugin;
 
 
     public OutgoingManager(CourierPrime plugin){
+        this.plugin = plugin;
         outgoing = new HashMap<>();
         outgoingConfig = plugin.getConfigManager().getOutgoingConfig();
     }
@@ -39,21 +43,28 @@ public class OutgoingManager {
      * @param uuid player to save outgoing data
      */
     private void savePlayer(UUID uuid) {
-        if (hasPendingLetters(uuid))
-            outgoingConfig.set(uuid.toString(), outgoing.get(uuid));
+        LinkedList<ItemStack> letters = outgoing.get(uuid);
+        if (hasPendingLetters(uuid) && letters != null) {
+            List<ItemStack> copies = copyItems(letters);
+            if (!copies.isEmpty()) {
+                outgoingConfig.set(uuid.toString(), copies);
+            }
+        }
     }
 
     /**
      * save all outgoing letters to file
      */
     public void saveAll() {
-        for (String key : outgoingConfig.getKeys(false)) {
-            outgoingConfig.set(key, null);
+        synchronized (outgoing) {
+            for (String key : new LinkedHashSet<>(outgoingConfig.getKeys(false))) {
+                outgoingConfig.set(key, null);
+            }
+            for (UUID player : new ArrayList<>(outgoing.keySet())) {
+                savePlayer(player);
+            }
+            plugin.getConfigManager().saveOutgoingConfig();
         }
-        for (UUID player : outgoing.keySet()) {
-            savePlayer(player);
-        }
-        CourierPrime.getPlugin().getConfigManager().saveOutgoingConfig();
     }
 
     /**
@@ -61,38 +72,105 @@ public class OutgoingManager {
      *
      * @param player player to load data for
      */
-    private void loadPlayer(UUID player) {
-        List<?> storedLetters = outgoingConfig.getList(player.toString());
+    private void loadPlayer(UUID player, String key) {
+        Object storedValue;
+        try {
+            storedValue = outgoingConfig.get(key);
+        } catch (RuntimeException exception) {
+            warn("Ignoring malformed outgoing value for recipient " + key, exception);
+            return;
+        }
+
+        if (!(storedValue instanceof List<?> storedLetters)) {
+            warn("Ignoring malformed outgoing value for recipient " + key, null);
+            return;
+        }
+
         LinkedList<ItemStack> letters = new LinkedList<>();
-        if (storedLetters != null) {
-            for (Object storedLetter : storedLetters) {
-                if (storedLetter instanceof ItemStack itemStack) {
-                    letters.add(itemStack);
+        for (Object storedLetter : storedLetters) {
+            if (!(storedLetter instanceof ItemStack itemStack)) {
+                warn("Ignoring malformed outgoing item for recipient " + key, null);
+                continue;
+            }
+
+            try {
+                if (itemStack.getType() == null || itemStack.getType().isAir() || itemStack.getAmount() <= 0) {
+                    warn("Ignoring empty or malformed outgoing item for recipient " + key, null);
+                    continue;
                 }
+                letters.add(itemStack.clone());
+            } catch (RuntimeException exception) {
+                warn("Ignoring malformed outgoing item for recipient " + key, exception);
             }
         }
-        outgoing.put(player, letters);
+
+        if (!letters.isEmpty()) {
+            outgoing.put(player, letters);
+        }
     }
 
     /**
      * load all outgoing letters from file
      */
     public void loadAll() {
-        for (String key : outgoingConfig.getKeys(false)) {
-            try {
-                loadPlayer(UUID.fromString(key));
-            } catch (IllegalArgumentException e) {
-                CourierPrime.getPlugin().getLogger().warning("Ignoring invalid recipient UUID in outgoing.yml: " + key);
+        synchronized (outgoing) {
+            outgoing.clear();
+
+            for (String key : new LinkedHashSet<>(outgoingConfig.getKeys(false))) {
+                final UUID player;
+                try {
+                    player = UUID.fromString(key);
+                } catch (IllegalArgumentException | NullPointerException exception) {
+                    warn("Ignoring invalid recipient UUID in outgoing.yml: " + key, exception);
+                    continue;
+                }
+
+                loadPlayer(player, key);
             }
         }
     }
 
     public boolean hasPendingLetters(Player player){
-        return (getOutgoing().containsKey(player.getUniqueId()) && getOutgoing().get(player.getUniqueId()).size() > 0);
+        return player != null && hasPendingLetters(player.getUniqueId());
     }
 
     public boolean hasPendingLetters(UUID uuid){
-        return (getOutgoing().containsKey(uuid) && getOutgoing().get(uuid).size() > 0);
+        if (uuid == null) {
+            return false;
+        }
+        synchronized (outgoing) {
+            LinkedList<ItemStack> letters = outgoing.get(uuid);
+            return letters != null && !letters.isEmpty();
+        }
+    }
+
+    private List<ItemStack> copyItems(List<ItemStack> letters) {
+        List<ItemStack> copies = new ArrayList<>();
+        for (ItemStack letter : letters) {
+            if (letter == null) {
+                warn("Ignoring null outgoing item while saving outgoing.yml", null);
+                continue;
+            }
+
+            try {
+                if (letter.getType() == null || letter.getType().isAir() || letter.getAmount() <= 0) {
+                    warn("Ignoring empty or malformed outgoing item while saving outgoing.yml", null);
+                    continue;
+                }
+                copies.add(letter.clone());
+            } catch (RuntimeException exception) {
+                warn("Ignoring malformed outgoing item while saving outgoing.yml", exception);
+            }
+        }
+        return copies;
+    }
+
+    private void warn(String message, Throwable exception) {
+        if (exception == null) {
+            plugin.getLogger().warning(message);
+        } else {
+            plugin.getLogger().warning(message + ": " + exception.getMessage());
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- resolve online and known-offline recipients safely, including comma/whitespace-separated and deduplicated multi-send
- validate all recipients before queueing or mutating the source letter; persist independent copies and make forwarding atomic
- tolerate malformed outgoing YAML data, preserve pending mail across full inventories, and save send/receive state

## Verification
- ./gradlew clean build (successful; shaded JAR built)
- ./gradlew test (successful; NO-SOURCE)
- git diff --check HEAD^..HEAD (clean)

Real Paper-server runtime checks remain unexecuted. PR_FEATURE_BREAKDOWN.md remains untracked and is not included.