### PR TITLE
fix: harden letter metadata and page handling

### DIFF
--- a/src/main/java/com/joaorihan/courierprime/command/ForwardCommand.java
+++ b/src/main/java/com/joaorihan/courierprime/command/ForwardCommand.java
@@ -2,9 +2,12 @@ package com.joaorihan.courierprime.command;
 
 import com.joaorihan.courierprime.config.Message;
 import com.joaorihan.courierprime.letter.LetterSender;
+import com.joaorihan.courierprime.letter.LetterUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.StringUtil;
 
 import java.util.ArrayList;
@@ -37,6 +40,18 @@ public class ForwardCommand extends AbstractCommand{
             return;
         }
 
+        ItemStack letter = player.getInventory().getItemInMainHand();
+        if (LetterUtil.isHoldingLetter(player) && !LetterUtil.wasAlreadyForwarded(letter)) {
+            if (!player.hasPermission("courierprime.post.one")) {
+                player.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
+                return;
+            }
+
+            if (!isResolvableRecipient(player, args[0])) {
+                return;
+            }
+        }
+
         // Command exec
         getPlugin().getLetterManager().getLetterSender().forward(player, args[0]);
 
@@ -49,6 +64,19 @@ public class ForwardCommand extends AbstractCommand{
         for (Player player : Bukkit.getOnlinePlayers()){
             names.add(player.getName());
         }
-        return StringUtil.copyPartialMatches(args[0], names, new ArrayList<>());
+        String partial = args.length == 0 ? "" : args[0];
+        return StringUtil.copyPartialMatches(partial, names, new ArrayList<>());
+    }
+
+    private boolean isResolvableRecipient(Player sender, String recipient) {
+        String trimmedRecipient = recipient == null ? "" : recipient.trim();
+        OfflinePlayer target = trimmedRecipient.isEmpty() ? null : Bukkit.getOfflinePlayer(trimmedRecipient);
+        if (target == null || target.getName() == null
+                || (!target.isOnline() && !target.hasPlayedBefore())) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_PLAYER_NO_EXIST, true)
+                    .replace("$PLAYER$", trimmedRecipient));
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/command/InspectCommand.java
+++ b/src/main/java/com/joaorihan/courierprime/command/InspectCommand.java
@@ -37,8 +37,11 @@ public class InspectCommand extends AbstractCommand{
 
         // Command execution
         String author = LetterUtil.getLetterAuthor(player);
+        if (author == null || author.isBlank()) {
+            author = "Unknown";
+        }
         player.sendMessage(getMessageManager().getMessage(Message.LETTER_BY, true)
-                .replace("$PLAYER$", author == null ? "Unknown" : author));
+                .replace("$PLAYER$", author));
 
     }
 

--- a/src/main/java/com/joaorihan/courierprime/letter/LetterManager.java
+++ b/src/main/java/com/joaorihan/courierprime/letter/LetterManager.java
@@ -7,6 +7,7 @@ import com.joaorihan.courierprime.config.Message;
 import com.joaorihan.courierprime.config.MessageManager;
 import lombok.Getter;
 import org.apache.commons.text.WordUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -74,10 +75,16 @@ public class LetterManager {
      * @param message the message the player is writing to the letter
      */
     public void writeBook(Player player, String message, boolean anonymous) {
-        String finalMessage = MessageManager.format(message);
+        String sourceMessage = message == null ? "" : message;
+        String finalMessage = MessageManager.format(sourceMessage);
+        if (finalMessage == null) {
+            finalMessage = "";
+        }
         
         ItemStack book = new ItemStack(Material.WRITTEN_BOOK, 1);
-        BookMeta bm = (BookMeta) book.getItemMeta();
+        if (!(book.getItemMeta() instanceof BookMeta bm)) {
+            return;
+        }
 
         PersistentDataContainer pdc = bm.getPersistentDataContainer();
         pdc.set(key, PersistentDataType.STRING, player.getName());
@@ -91,20 +98,7 @@ public class LetterManager {
         pages.addAll(splitIntoPages(finalMessage));
         bm.setPages(pages);
 
-        ArrayList<String> lore = new ArrayList<>();
-        Calendar currentDate = Calendar.getInstance();
-        SimpleDateFormat formatter = new SimpleDateFormat(plugin.getMessageManager().getMessage(Message.DATE_TIME_FORMAT));
-        String dateNow = formatter.format(currentDate.getTime());
-        String wrapped = WordUtils.wrap(MessageManager.unformat(message), 30, "<split>", true);
-        String[] lines = wrapped.split("<split>");
-        lore.add("");
-        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[0]);
-        if (lines.length >= 2) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[1]);
-        if (lines.length >= 3) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[2]);
-        lore.add("");
-        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FOOTER).replace("$DATE$", dateNow)
-                .replace("$PAGES$", Integer.toString(bm.getPages().size())));
-        bm.setLore(lore);
+        bm.setLore(createPreviewLore(sourceMessage, pages.size()));
 
         // Sets the letter custom model data, if enabled in the config
         if (MainConfig.isCustomModelData()){
@@ -135,41 +129,38 @@ public class LetterManager {
      * @param message message player is adding to the letter
      */
     public void editBook(Player player, String message) {
-        String finalMessage = MessageManager.format(message);
+        if (player == null) {
+            return;
+        }
+
+        String sourceMessage = message == null ? "" : message;
+        String finalMessage = MessageManager.format(sourceMessage);
+        if (finalMessage == null) {
+            finalMessage = "";
+        }
         
         ItemStack writtenBook = player.getInventory().getItemInMainHand();
-        BookMeta wbm = (BookMeta) writtenBook.getItemMeta();
-        
-        ArrayList<String> pages = new ArrayList<>(wbm.getPages());
+        if (writtenBook == null || !(writtenBook.getItemMeta() instanceof BookMeta wbm)) {
+            return;
+        }
+
+        ArrayList<String> pages = normalizePages(wbm.getPages());
         if (pages.isEmpty()) {
             pages.add("");
         }
-        if (pages.get(pages.size() - 1).length() > 0
-                && pages.get(pages.size() - 1).length() + finalMessage.length() <= MAX_BOOK_PAGE_LENGTH) {
-            String sb = pages.get(pages.size() - 1) +
-                    finalMessage;
-            pages.set(pages.size() - 1, sb);
-            player.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_PAGE_EDITED, true));
-        } else {
-            pages.addAll(splitIntoPages(finalMessage));
+
+        trimTrailingEmptyPages(pages);
+        int pageCountBeforeEdit = pages.size();
+        boolean addedPage = appendToPages(pages, finalMessage);
+        if (addedPage || pages.size() > pageCountBeforeEdit) {
             player.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_PAGE_ADDED, true));
+        } else {
+            player.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_PAGE_EDITED, true));
         }
         wbm.setPages(pages);
 
-        ArrayList<String> lore = new ArrayList<>();
-        Calendar currentDate = Calendar.getInstance();
-        SimpleDateFormat formatter = new SimpleDateFormat(plugin.getMessageManager().getMessage(Message.DATE_TIME_FORMAT));
-        String dateNow = formatter.format(currentDate.getTime());
-        String wrapped = WordUtils.wrap(MessageManager.unformat(wbm.getPage(1)), 30, "<split>", true);
-        String[] lines = wrapped.split("<split>");
-        lore.add("");
-        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[0]);
-        if (lines.length >= 2) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[1]);
-        if (lines.length >= 3) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[2]);
-        lore.add("");
-        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FOOTER).replace("$DATE$", dateNow)
-                .replace("$PAGES$", Integer.toString(wbm.getPages().size())));
-        wbm.setLore(lore);
+        String firstPage = pages.isEmpty() ? "" : pages.get(0);
+        wbm.setLore(createPreviewLore(firstPage, pages.size()));
         writtenBook.setItemMeta(wbm);
         
         player.getInventory().setItemInMainHand(writtenBook);
@@ -177,15 +168,89 @@ public class LetterManager {
 
     private List<String> splitIntoPages(String message) {
         ArrayList<String> pages = new ArrayList<>();
-        if (message.isEmpty()) {
+        String safeMessage = message == null ? "" : message;
+        if (safeMessage.isEmpty()) {
             pages.add("");
             return pages;
         }
 
-        for (int start = 0; start < message.length(); start += MAX_BOOK_PAGE_LENGTH) {
-            pages.add(message.substring(start, Math.min(start + MAX_BOOK_PAGE_LENGTH, message.length())));
+        for (int start = 0; start < safeMessage.length(); start += MAX_BOOK_PAGE_LENGTH) {
+            pages.add(safeMessage.substring(start, Math.min(start + MAX_BOOK_PAGE_LENGTH, safeMessage.length())));
         }
         return pages;
+    }
+
+    private ArrayList<String> normalizePages(List<String> existingPages) {
+        ArrayList<String> pages = new ArrayList<>();
+        if (existingPages == null) {
+            return pages;
+        }
+
+        for (String page : existingPages) {
+            pages.addAll(splitIntoPages(page == null ? "" : page));
+        }
+        return pages;
+    }
+
+    private void trimTrailingEmptyPages(List<String> pages) {
+        while (pages.size() > 1 && pages.get(pages.size() - 1).isEmpty()) {
+            pages.remove(pages.size() - 1);
+        }
+    }
+
+    private boolean appendToPages(List<String> pages, String message) {
+        if (message == null || message.isEmpty()) {
+            return false;
+        }
+
+        if (pages.isEmpty()) {
+            pages.add("");
+        }
+
+        int lastPageIndex = pages.size() - 1;
+        String lastPage = pages.get(lastPageIndex);
+        if (lastPage == null) {
+            lastPage = "";
+        }
+
+        int remainingCapacity = Math.max(0, MAX_BOOK_PAGE_LENGTH - lastPage.length());
+        int firstPageLength = Math.min(remainingCapacity, message.length());
+        if (firstPageLength > 0) {
+            pages.set(lastPageIndex, lastPage + message.substring(0, firstPageLength));
+        }
+
+        if (firstPageLength == message.length()) {
+            return false;
+        }
+
+        pages.addAll(splitIntoPages(message.substring(firstPageLength)));
+        return true;
+    }
+
+    private ArrayList<String> createPreviewLore(String content, int pageCount) {
+        ArrayList<String> lore = new ArrayList<>();
+        Calendar currentDate = Calendar.getInstance();
+        SimpleDateFormat formatter = new SimpleDateFormat(plugin.getMessageManager().getMessage(Message.DATE_TIME_FORMAT));
+        String dateNow = formatter.format(currentDate.getTime());
+
+        String safeContent = content == null ? "" : content;
+        String preview = ChatColor.stripColor(MessageManager.unformat(safeContent));
+        if (preview == null) {
+            preview = "";
+        }
+        String wrapped = WordUtils.wrap(preview, 30, "<split>", true);
+        if (wrapped == null) {
+            wrapped = "";
+        }
+        String[] lines = wrapped.isEmpty() ? new String[]{""} : wrapped.split("<split>", -1);
+        lore.add("");
+        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[0]);
+        if (lines.length >= 2) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[1]);
+        if (lines.length >= 3) lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FORMAT) + lines[2]);
+        lore.add("");
+        lore.add(plugin.getMessageManager().getMessage(Message.PREVIEW_FOOTER).replace("$DATE$", dateNow)
+                .replace("$PAGES$", Integer.toString(pageCount)));
+        return lore;
     }
     
     /**

--- a/src/main/java/com/joaorihan/courierprime/letter/LetterUtil.java
+++ b/src/main/java/com/joaorihan/courierprime/letter/LetterUtil.java
@@ -5,6 +5,7 @@ import com.joaorihan.courierprime.CourierPrime;
 import com.joaorihan.courierprime.config.Message;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -12,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.persistence.PersistentDataType;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,16 +31,32 @@ public class LetterUtil {
      * @return if the item was a valid plugin Letter or not
      */
     public boolean isValidLetter(ItemStack item){
-        if (item == null || !item.getType().equals(Material.WRITTEN_BOOK))
+        if (item == null || item.getType() != Material.WRITTEN_BOOK)
             return false;
 
-        if (!(item.getItemMeta() instanceof BookMeta bookMeta) || bookMeta.getTitle() == null) {
+        if (!(item.getItemMeta() instanceof BookMeta bookMeta)) {
             return false;
         }
 
-        String letterTitle = CourierPrime.getPlugin().getMessageManager().getMessage(Message.LETTER_FROM)
-                .replace("$PLAYER$", "");
-        return bookMeta.getTitle().contains(letterTitle);
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin == null || plugin.getLetterManager() == null) {
+            return false;
+        }
+
+        NamespacedKey ownerKey = plugin.getLetterManager().getOwnerKey();
+        String ownerUuid = readPersistentString(bookMeta, ownerKey);
+        if (hasPersistentKey(bookMeta, ownerKey) || ownerUuid != null) {
+            return normalizeUuid(ownerUuid) != null;
+        }
+
+        String ownerName = readPersistentString(bookMeta, plugin.getLetterManager().getKey());
+        if (ownerName != null && !ownerName.isBlank()) {
+            return true;
+        }
+
+        // Very old delivered copies did not retain the PDC. Keep a strict presentation
+        // fallback, but never accept a title merely because it contains a phrase.
+        return hasLegacyLetterPresentation(bookMeta, plugin);
     }
 
     /**
@@ -60,38 +78,57 @@ public class LetterUtil {
             return false;
         }
 
-        String ownerUuid = getLetterOwnerUuid(player);
-        if (ownerUuid != null) {
-            return ownerUuid.equals(player.getUniqueId().toString());
+        if (hasLetterOwnerUuid(player)) {
+            String ownerUuid = getLetterOwnerUuid(player);
+            return ownerUuid != null && ownerUuid.equals(player.getUniqueId().toString());
         }
 
         // Preserve compatibility with letters created before UUID ownership was stored.
         return Objects.equals(getLetterOwner(player), player.getName());
     }
 
-    public boolean wasAlreadySent(@NonNull ItemStack letter){
-        if (!(letter.getItemMeta() instanceof BookMeta bookMeta) || bookMeta.getLore() == null) {
+    public boolean wasAlreadySent(ItemStack letter){
+        BookMeta bookMeta = getBookMeta(letter);
+        if (bookMeta == null) {
             return false;
         }
 
-        String lore = String.join("\n", bookMeta.getLore());
-        String destinationMarker = CourierPrime.getPlugin().getMessageManager()
-                .getMessage(Message.LETTER_TO_ONE).replace("$PLAYER$", "");
-        return lore.contains("&8To")
-                || lore.contains(destinationMarker)
-                || lore.contains(CourierPrime.getPlugin().getMessageManager().getMessage(Message.LETTER_TO_MULTIPLE))
-                || lore.contains(CourierPrime.getPlugin().getMessageManager().getMessage(Message.LETTER_TO_ALL))
-                || lore.contains(CourierPrime.getPlugin().getMessageManager().getMessage(Message.LETTER_TO_ALLONLINE));
+        if (bookMeta.getGeneration() == BookMeta.Generation.COPY_OF_ORIGINAL) {
+            return true;
+        }
+
+        if (bookMeta.getLore() == null) {
+            return false;
+        }
+
+        for (String loreLine : bookMeta.getLore()) {
+            if (isSentMarker(loreLine)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    public boolean wasAlreadyForwarded(@NonNull ItemStack letter){
-        if (!(letter.getItemMeta() instanceof BookMeta bookMeta) || bookMeta.getLore() == null) {
+    public boolean wasAlreadyForwarded(ItemStack letter){
+        BookMeta bookMeta = getBookMeta(letter);
+        if (bookMeta == null) {
             return false;
         }
 
-        String marker = CourierPrime.getPlugin().getMessageManager()
-                .getMessage(Message.LETTER_FORWARDED_BY).replace("$PLAYER$", "");
-        return String.join("\n", bookMeta.getLore()).contains(marker);
+        if (bookMeta.getGeneration() == BookMeta.Generation.COPY_OF_ORIGINAL) {
+            return true;
+        }
+
+        if (bookMeta.getLore() == null) {
+            return false;
+        }
+
+        for (String loreLine : bookMeta.getLore()) {
+            if (isForwardedMarker(loreLine)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -101,43 +138,181 @@ public class LetterUtil {
      * might need to be changed to OfflinePlayer, in case of player name change issues
      */
     public String getLetterOwner(@NonNull Player player){
-        ItemStack book = player.getInventory().getItemInMainHand();
-        if (!(book.getItemMeta() instanceof BookMeta bm)) {
+        BookMeta bookMeta = getHoldingBookMeta(player);
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (bookMeta == null || plugin == null || plugin.getLetterManager() == null) {
             return null;
         }
-        NamespacedKey key = CourierPrime.getPlugin().getLetterManager().getKey();
-
-        if (bm.getPersistentDataContainer().has(key, PersistentDataType.STRING))
-            return bm.getPersistentDataContainer().get(key, PersistentDataType.STRING);
-
-        return null;
+        return readPersistentString(bookMeta, plugin.getLetterManager().getKey());
     }
 
     public String getLetterAuthor(@NonNull Player player) {
-        ItemStack book = player.getInventory().getItemInMainHand();
-        if (!(book.getItemMeta() instanceof BookMeta bookMeta)) {
-            return null;
-        }
-        return bookMeta.getAuthor();
+        BookMeta bookMeta = getHoldingBookMeta(player);
+        return bookMeta == null ? null : bookMeta.getAuthor();
     }
 
     private String getLetterOwnerUuid(@NonNull Player player) {
-        ItemStack book = player.getInventory().getItemInMainHand();
-        if (!(book.getItemMeta() instanceof BookMeta bookMeta)) {
+        BookMeta bookMeta = getHoldingBookMeta(player);
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (bookMeta == null || plugin == null || plugin.getLetterManager() == null) {
             return null;
         }
 
-        NamespacedKey ownerKey = CourierPrime.getPlugin().getLetterManager().getOwnerKey();
-        String ownerUuid = bookMeta.getPersistentDataContainer().get(ownerKey, PersistentDataType.STRING);
-        if (ownerUuid == null) {
+        return normalizeUuid(readPersistentString(bookMeta, plugin.getLetterManager().getOwnerKey()));
+    }
+
+    private BookMeta getBookMeta(ItemStack item) {
+        if (item == null || !(item.getItemMeta() instanceof BookMeta bookMeta)) {
+            return null;
+        }
+        return bookMeta;
+    }
+
+    private BookMeta getHoldingBookMeta(Player player) {
+        if (player == null || player.getInventory() == null) {
+            return null;
+        }
+        return getBookMeta(player.getInventory().getItemInMainHand());
+    }
+
+    private String readPersistentString(BookMeta bookMeta, NamespacedKey key) {
+        if (bookMeta == null || key == null || bookMeta.getPersistentDataContainer() == null) {
             return null;
         }
 
         try {
-            return UUID.fromString(ownerUuid).toString();
-        } catch (IllegalArgumentException e) {
+            return bookMeta.getPersistentDataContainer().get(key, PersistentDataType.STRING);
+        } catch (RuntimeException ignored) {
             return null;
         }
+    }
+
+    private boolean hasPersistentKey(BookMeta bookMeta, NamespacedKey key) {
+        if (bookMeta == null || key == null || bookMeta.getPersistentDataContainer() == null) {
+            return false;
+        }
+
+        try {
+            return bookMeta.getPersistentDataContainer().has(key);
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private boolean hasLetterOwnerUuid(@NonNull Player player) {
+        BookMeta bookMeta = getHoldingBookMeta(player);
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin == null || plugin.getLetterManager() == null) {
+            return false;
+        }
+
+        NamespacedKey ownerKey = plugin.getLetterManager().getOwnerKey();
+        return hasPersistentKey(bookMeta, ownerKey) || readPersistentString(bookMeta, ownerKey) != null;
+    }
+
+    private String normalizeUuid(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return UUID.fromString(value).toString();
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private boolean hasLegacyLetterPresentation(BookMeta bookMeta, CourierPrime plugin) {
+        String title = bookMeta.getTitle();
+        String author = bookMeta.getAuthor();
+        if (title == null || title.isBlank() || author == null || author.isBlank()
+                || bookMeta.getPageCount() <= 0 || plugin.getMessageManager() == null) {
+            return false;
+        }
+
+        String titlePattern = plugin.getMessageManager().getMessage(Message.LETTER_FROM);
+        String titlePrefix = titlePattern == null ? "" : titlePattern.replace("$PLAYER$", "");
+        return !titlePrefix.isBlank() && title.equals(titlePrefix + author);
+    }
+
+    private boolean isSentMarker(String loreLine) {
+        if (loreLine == null || loreLine.isBlank()) {
+            return false;
+        }
+
+        // §T is the current stable destination marker, including multiple/all variants.
+        if (loreLine.startsWith("§T") || loreLine.startsWith("&T")) {
+            return true;
+        }
+
+        // Keep the raw and formatted legacy English marker used by older versions.
+        if (loreLine.contains("&8To") || loreLine.contains("§8To")) {
+            return true;
+        }
+
+        CourierPrime plugin = CourierPrime.getPlugin();
+        boolean legacyDestinationStyle = loreLine.startsWith("§8") || loreLine.startsWith("&8");
+        if (plugin != null && plugin.getMessageManager() != null) {
+            for (Message message : new Message[]{
+                    Message.LETTER_TO_ONE,
+                    Message.LETTER_TO_MULTIPLE,
+                    Message.LETTER_TO_ALL,
+                    Message.LETTER_TO_ALLONLINE
+            }) {
+                String marker = plugin.getMessageManager().getMessage(message);
+                marker = marker == null ? "" : marker.replace("$PLAYER$", "");
+                if (legacyDestinationStyle && !marker.isBlank() && loreLine.contains(marker)) {
+                    return true;
+                }
+
+                String normalizedMarker = normalizeText(marker);
+                if (legacyDestinationStyle && !normalizedMarker.isBlank()
+                        && normalizeText(loreLine).startsWith(normalizedMarker)) {
+                    return true;
+                }
+            }
+        }
+
+        // The shipped Portuguese locale is also used by legacy letters when the server locale changes.
+        if (!legacyDestinationStyle) {
+            return false;
+        }
+        String normalized = normalizeText(loreLine).toLowerCase(Locale.ROOT);
+        return normalized.startsWith("to ") || normalized.startsWith("para ");
+    }
+
+    private boolean isForwardedMarker(String loreLine) {
+        if (loreLine == null || loreLine.isBlank()) {
+            return false;
+        }
+
+        boolean forwardedStyle = loreLine.startsWith("§7") || loreLine.startsWith("&7");
+        if (!forwardedStyle) {
+            return false;
+        }
+
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin != null && plugin.getMessageManager() != null) {
+            String marker = plugin.getMessageManager().getMessage(Message.LETTER_FORWARDED_BY);
+            marker = marker == null ? "" : marker.replace("$PLAYER$", "");
+            if ((!marker.isBlank() && loreLine.contains(marker))
+                    || (!normalizeText(marker).isBlank()
+                    && normalizeText(loreLine).contains(normalizeText(marker)))) {
+                return true;
+            }
+        }
+
+        String normalized = normalizeText(loreLine).toLowerCase(Locale.ROOT);
+        return normalized.contains("forwarded") || normalized.contains("encaminhad");
+    }
+
+    private String normalizeText(String text) {
+        if (text == null) {
+            return "";
+        }
+        String translated = ChatColor.translateAlternateColorCodes('&', text);
+        String stripped = ChatColor.stripColor(translated);
+        return stripped == null ? "" : stripped.trim();
     }
 
 


### PR DESCRIPTION
## Summary
- enforce UUID ownership metadata as authoritative while preserving legacy name fallback
- harden letter recognition, inspection, forwarding detection, and malformed-book handling
- split writes and edits into valid 256-character pages

## Verification
- ./gradlew clean build (successful; shadowJar succeeded)
- ./gradlew test (successful; NO-SOURCE)
- git diff --check HEAD^..HEAD (successful)

The untracked PR_FEATURE_BREAKDOWN.md was preserved and is not part of the commit.