### PR TITLE
refactor: Complete courier contract and lifecycle

### DIFF
--- a/PR_FEATURE_BREAKDOWN.md
+++ b/PR_FEATURE_BREAKDOWN.md
@@ -1,0 +1,386 @@
+# CourierPrime WIP Feature Breakdown
+
+This document separates the current `feature/custom-entity-couriers` work into features that can be implemented, reviewed, tested, and merged independently.
+
+## Current status
+
+- `origin/main`: `4a21d09`
+- `feature/custom-entity-couriers` and its remote tracking branch: `65f7c6c` (`test: testing mm integration`)
+- The pushed branch contains a compile-blocking call in `CustomEntityManager`:
+
+  ```java
+  return activeProvider.spawnEntity(, location);
+  ```
+
+- The working directory contains additional uncommitted changes beyond that pushed commit.
+- `CourierType.java` is currently untracked and must be included in any commit that uses the new courier-type design.
+- The current working directory builds successfully with the configured Paper 26.2 / Java 25 toolchain, but Gradle reports `test NO-SOURCE`; there are no automated tests.
+
+The pushed branch should therefore be treated as the original WIP baseline. The local worktree is a later, broader implementation pass and should not be merged as one undifferentiated change.
+
+## Recommended merge strategy
+
+Use the following order. Each item should be its own branch or clearly separated commit series.
+
+1. Decide and document the supported Paper/Java baseline.
+2. Implement the courier-type abstraction and vanilla selection without external plugins.
+3. Add MythicMobs integration.
+4. Add ModelEngine integration.
+5. Harden courier lifecycle and retry behavior.
+6. Merge the mail delivery and persistence fixes separately.
+7. Merge letter metadata and forwarding fixes separately.
+8. Merge reload/configuration robustness and documentation.
+
+The platform upgrade should be a separate PR unless the project explicitly wants the custom-courier PR to raise the minimum supported Paper and Java versions.
+
+## Feature F0 — Define the custom courier contract
+
+### Purpose
+
+Replace the incomplete global custom-entity design from the pushed branch with one clear contract for selecting and spawning couriers.
+
+### Current problem
+
+The pushed implementation introduces `custom-entities.enabled`, `entity-id`, and `preferred-plugin`, but the spawn call does not pass an entity ID and cannot compile. The working tree instead introduces per-player values such as `mm:CourierOwl` and `meg:delivery_dragon`.
+
+### Recommended contract
+
+- Vanilla type: `VILLAGER`, `COW`, `PARROT`, etc.
+- MythicMobs type: `mm:<mob-id>`
+- ModelEngine type: `meg:<model-id>`
+- `enabled-courier-types` controls what players may select.
+- An administrator may assign a valid type directly with `/courier set`.
+- A failed custom spawn falls back to the configured vanilla default.
+
+### Work
+
+- Remove the unused global `custom-entities.entity-id` and `preferred-plugin` behavior, or provide an explicit migration from it.
+- Make every spawn request carry the selected courier type or provider plus identifier.
+- Decide whether `/courier set` should support offline players.
+- Decide whether a saved custom selection remains valid when the dependency is later disabled. The current implementation falls back to vanilla.
+
+### Acceptance criteria
+
+- The plugin compiles from a clean clone.
+- The configuration and command documentation describe the same model.
+- A server without MythicMobs or ModelEngine still starts and supports vanilla couriers.
+- Invalid custom types never reach the spawn provider.
+
+## Feature F1 — Courier type parsing, selection, and persistence
+
+### Purpose
+
+Give players and administrators a safe way to choose a courier type, independent of the provider implementation.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/courier/CourierType.java`
+- `src/main/java/com/joaorihan/courierprime/courier/CourierSelectManager.java`
+- `src/main/java/com/joaorihan/courierprime/command/CourierSelectCommand.java`
+- `src/main/java/com/joaorihan/courierprime/config/MainConfig.java`
+- `src/main/resources/config.yml`
+- `src/main/resources/lang/en-us.yml`
+- `src/main/resources/lang/pt-br.yml`
+- The selection-related portion of `Courier.java`
+
+### Behavior
+
+- Parse spawnable vanilla `EntityType` values.
+- Parse and normalize `mm:` and `meg:` values.
+- Persist selections in `couriers.yml`.
+- Preserve existing vanilla selections.
+- Reject malformed UUIDs and malformed saved values without preventing startup.
+- Support `/courier select <type>`.
+- Support administrator-only `/courier set <player> <type>`.
+
+### Acceptance criteria
+
+- `/courier select cow` succeeds when `COW` is enabled.
+- An unenabled vanilla type is rejected by `/courier select`.
+- `/courier set <player> sheep` works for an administrator even when `SHEEP` is not enabled for normal selection.
+- Invalid types do not overwrite an existing valid selection.
+- A restart preserves the selected type.
+- Tab completion and the documented command syntax agree.
+
+### Follow-up issue
+
+The current administrator tab completion only lists enabled types, even though administrator assignment intentionally bypasses the enabled list. Either list all valid built-in types for administrators or document that disabled types must be entered manually.
+
+## Feature F2 — MythicMobs courier provider
+
+### Purpose
+
+Spawn a selected MythicMobs mob as the courier without making MythicMobs mandatory.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/integration/CustomEntityProvider.java`
+- `src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java`
+- `src/main/java/com/joaorihan/courierprime/integration/MythicMobsProvider.java`
+- `build.gradle.kts`
+- `src/main/resources/plugin.yml`
+- The custom-spawn portion of `Courier.java`
+
+### Behavior
+
+- Detect MythicMobs only when it is installed and enabled.
+- Validate the requested mob ID before saving a selection.
+- Spawn the requested mob through the MythicMobs API.
+- Return the Bukkit entity to the normal courier lifecycle.
+- Fall back to a vanilla courier if the provider is unavailable or spawning fails.
+
+### Acceptance criteria
+
+- The plugin starts with no MythicMobs installation.
+- `/courier select mm:<valid-id>` succeeds with MythicMobs installed.
+- A valid MythicMobs courier can be clicked and delivers mail.
+- `/courier select mm:<invalid-id>` is rejected and does not change the saved selection.
+- Disabling MythicMobs does not crash the server or prevent vanilla delivery.
+- The actual MythicMobs version used on the server matches the compile-only API version closely enough for runtime operation.
+
+## Feature F3 — ModelEngine courier provider
+
+### Purpose
+
+Spawn a vanilla host entity with a ModelEngine model attached.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/integration/ModelEngineProvider.java`
+- `src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java`
+- `build.gradle.kts`
+- `src/main/resources/config.yml`
+- `src/main/resources/plugin.yml`
+- The custom-spawn portion of `Courier.java`
+
+### Behavior
+
+- Detect ModelEngine only when it is installed and enabled.
+- Validate the model/blueprint ID before saving a selection.
+- Spawn the configured base entity.
+- Attach the requested model.
+- Remove the base entity if model creation or attachment fails.
+- Fall back to a vanilla courier when the provider cannot spawn the model.
+
+### Acceptance criteria
+
+- The plugin starts without ModelEngine installed.
+- A valid `meg:<model-id>` selection spawns a visible, clickable courier.
+- The configured `modelengine-base-entity` is honored.
+- Invalid model IDs are rejected.
+- Failed model creation does not leave an invisible or orphaned host entity.
+- Disabling ModelEngine does not crash the server or prevent vanilla delivery.
+
+## Feature F4 — Courier lifecycle and retry hardening
+
+### Purpose
+
+Ensure all courier types behave consistently after death, timeout, reload, movement, or duplicate spawn attempts.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/courier/Courier.java`
+- `src/main/java/com/joaorihan/courierprime/courier/CourierManager.java`
+- The active-courier cleanup portion of `ConfigManager` and `CourierPrime`
+
+### Behavior
+
+- Do not cast every courier to `LivingEntity`.
+- Remove dead entities from the active map.
+- Avoid two active couriers for one recipient.
+- Retry undelivered mail after timeout or external entity removal.
+- Preserve click delivery for vanilla, MythicMobs, and ModelEngine host entities.
+
+### Acceptance criteria
+
+- A courier is removed after the configured timeout.
+- An undelivered letter eventually receives a replacement courier.
+- Killing a courier does not leave a stale map entry.
+- Repeated join/reload events do not create duplicate couriers.
+- Non-living but valid configured entities do not produce a `ClassCastException`.
+- A delivered courier does not send an “ignored” message.
+
+## Feature F5 — Mail recipient resolution and persistence
+
+### Purpose
+
+Make sending reliable for online players, known offline players, multiple recipients, and server restarts.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/letter/LetterSender.java`
+- `src/main/java/com/joaorihan/courierprime/letter/OutgoingManager.java`
+- `src/main/java/com/joaorihan/courierprime/command/PostCommand.java`
+
+### Behavior
+
+- Reject unknown recipients.
+- Do not cast offline recipients to `Player`.
+- Support comma-separated and whitespace-separated multiple recipients.
+- Save outgoing mail after send and receive operations.
+- Preserve undelivered mail when the inventory is full.
+- Load malformed outgoing data without crashing the plugin.
+
+### Acceptance criteria
+
+- Online delivery works.
+- Known offline delivery waits until the player joins.
+- Unknown players are rejected and the sender keeps the letter.
+- Multiple recipients each receive a copy.
+- A restart preserves pending mail.
+- A full inventory does not delete pending letters.
+- Console logs contain no cast, serialization, or null-pointer errors.
+
+### Remaining review point
+
+Forwarding currently changes the book generation to `COPY_OF_ORIGINAL` before recipient validation. A failed forward should leave the sender’s book unchanged; fix this before treating the forwarding/mail feature as complete.
+
+## Feature F6 — Letter metadata, ownership, forwarding, and page safety
+
+### Purpose
+
+Protect letter ownership and make inspection, anonymous letters, forwarding, and long messages reliable.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/letter/LetterManager.java`
+- `src/main/java/com/joaorihan/courierprime/letter/LetterUtil.java`
+- `src/main/java/com/joaorihan/courierprime/command/ForwardCommand.java`
+- `src/main/java/com/joaorihan/courierprime/command/InspectCommand.java`
+
+### Behavior
+
+- Store UUID ownership metadata for new letters.
+- Retain a legacy name-based fallback for old letters.
+- Keep anonymous letters anonymous in `/inspect`.
+- Mark successful forwards as copies.
+- Prevent resending or repeatedly forwarding the same letter.
+- Split long content into valid book pages.
+- Handle ordinary or malformed written books without exceptions.
+
+### Acceptance criteria
+
+- A player cannot send another player’s letter.
+- A player-name change does not break ownership of new letters.
+- `/inspect` reports the visible author, not hidden ownership metadata.
+- Anonymous letters display as anonymous.
+- A forwarded letter is marked as a copy and cannot be forwarded repeatedly.
+- Messages longer than 256 characters are delivered without book API errors.
+
+## Feature F7 — Reload, configuration validation, and message lifecycle
+
+### Purpose
+
+Make `/courieradmin reload` safe and ensure invalid configuration does not crash the server.
+
+### Files
+
+- `src/main/java/com/joaorihan/courierprime/CourierPrime.java`
+- `src/main/java/com/joaorihan/courierprime/config/ConfigManager.java`
+- `src/main/java/com/joaorihan/courierprime/config/MainConfig.java`
+- `src/main/java/com/joaorihan/courierprime/config/MessageManager.java`
+- `src/main/java/com/joaorihan/courierprime/command/AbstractCommand.java`
+- `src/main/java/com/joaorihan/courierprime/updates/UpdateChecker.java`
+- Language resources
+
+### Behavior
+
+- Cancel plugin tasks before rebuilding state.
+- Remove active couriers before reload.
+- Avoid registering duplicate listeners and commands.
+- Reschedule pending online mail after reload.
+- Fall back safely for invalid entity, gamemode, world, language, and ModelEngine host settings.
+- Make commands use the current message manager after reload.
+
+### Acceptance criteria
+
+- Reload does not duplicate event messages or commands.
+- Active couriers are removed exactly once.
+- Pending online mail is delivered after reload.
+- Invalid values produce warnings and safe defaults rather than startup failure.
+- Switching language and reloading changes command messages without restarting.
+
+## Feature F8 — Platform, build, packaging, and documentation
+
+### Purpose
+
+Upgrade and document the build/runtime baseline independently from gameplay behavior.
+
+### Files
+
+- `build.gradle.kts`
+- `gradle/wrapper/gradle-wrapper.properties`
+- `src/main/resources/plugin.yml`
+- `README.md`
+- `.gitignore`
+
+### Current changes
+
+- Gradle 9.6.1.
+- Shadow plugin 9.6.1.
+- Paper API 26.2.
+- Java 25 toolchain.
+- MythicMobs and ModelEngine compile-only dependencies.
+- Updated build and configuration documentation.
+- Ignored generated `bin/` output.
+
+### Acceptance criteria
+
+- `./gradlew clean build` succeeds from a clean checkout.
+- The shaded JAR is produced in `build/libs`.
+- The JAR starts on the documented Paper/Java versions.
+- The plugin does not crash when optional dependencies are absent.
+- The project’s supported-version policy is explicit. If Paper 1.21 / Java 21 support is still required, this upgrade must be revised or made a separate compatibility branch.
+
+## Recommended PR boundaries
+
+### PR 1 — Platform baseline
+
+Only include F8 if the minimum supported Paper and Java versions are intentionally changing. Do not mix mail behavior changes into this PR.
+
+### PR 2 — Courier type core
+
+Implement F0 and F1 with vanilla couriers only. This gives the project a complete, testable selection model before optional integrations are introduced.
+
+### PR 3 — MythicMobs integration
+
+Implement F2 and test with and without MythicMobs installed.
+
+### PR 4 — ModelEngine integration
+
+Implement F3 and test model attachment and cleanup independently.
+
+### PR 5 — Courier lifecycle
+
+Implement F4 and test timeout, death, retry, reload, and duplicate prevention across all courier types.
+
+### PR 6 — Mail delivery persistence
+
+Implement F5. This should be reviewable without requiring either optional entity plugin.
+
+### PR 7 — Letter integrity
+
+Implement F6, including the failed-forward mutation fix.
+
+### PR 8 — Reload and configuration robustness
+
+Implement F7, then update documentation and examples.
+
+## Final integration checklist
+
+Before merging the feature set, verify all of the following on a real Paper server using the shaded JAR:
+
+- Vanilla courier selection and persistence.
+- Startup with neither optional plugin installed.
+- Valid and invalid MythicMobs selections.
+- Valid and invalid ModelEngine selections.
+- Fallback after disabling an optional plugin.
+- Courier click delivery for each provider.
+- Courier death, timeout, retry, and duplicate prevention.
+- Online, offline, unknown, and multiple-recipient mail.
+- Inventory-full delivery and restart persistence.
+- Anonymous letters, forwarding, inspection, and long pages.
+- Reload with active couriers and pending mail.
+- Invalid configuration values and missing language keys.
+- Command registration and permissions on the target Paper version.
+- No `ClassCastException`, `NoClassDefFoundError`, `NullPointerException`, or `Could not pass event` messages in the console.

--- a/src/main/java/com/joaorihan/courierprime/command/CourierSelectCommand.java
+++ b/src/main/java/com/joaorihan/courierprime/command/CourierSelectCommand.java
@@ -4,16 +4,18 @@ import com.joaorihan.courierprime.config.MainConfig;
 import com.joaorihan.courierprime.config.Message;
 import com.joaorihan.courierprime.courier.CourierType;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
-public class CourierSelectCommand extends AbstractCommand{
-
+public class CourierSelectCommand extends AbstractCommand {
 
     public CourierSelectCommand() {
         super("courier",
@@ -24,121 +26,131 @@ public class CourierSelectCommand extends AbstractCommand{
 
     @Override
     public void execute(CommandSender sender, String[] args) {
-
-        // Command checks
-        if (!(sender instanceof Player player))
-            return;
-
-        boolean isAdmin = player.hasPermission("courierprime.admin");
-        if (!isAdmin && !player.hasPermission("courierprime.courier.select")) {
-            player.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
+        if (args.length == 0) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
             return;
         }
 
-        if (args.length < 2){
+        if (args[0].equalsIgnoreCase("select")) {
+            executeSelect(sender, args);
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("set")) {
+            executeSet(sender, args);
+            return;
+        }
+
+        sender.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
+    }
+
+    private void executeSelect(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            return;
+        }
+        if (!player.hasPermission("courierprime.courier.select")) {
+            player.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
+            return;
+        }
+        if (args.length < 2) {
             player.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
             return;
         }
 
-        // /courier select <entity>
-        if (args[0].equalsIgnoreCase("select")) {
-            if (!player.hasPermission("courierprime.courier.select")) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
-                return;
-            }
-
-            CourierType courierType = CourierType.parse(args[1]);
-
-            if (courierType == null) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
-                return;
-            }
-
-            // Check if the courier type is enabled in config
-            boolean isEnabled = MainConfig.getEnabledCourierTypes().stream()
-                    .anyMatch(type -> type.toString().equalsIgnoreCase(args[1]));
-
-            if (!isEnabled) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
-                return;
-            }
-
-            // Check if custom entity plugin is available
-            if (courierType.isMythicMobs() && !getPlugin().getCustomEntityManager().isMythicMobsAvailable()) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
-                        .replace("$PLUGIN$", "MythicMobs"));
-                return;
-            }
-
-            if (courierType.isModelEngine() && !getPlugin().getCustomEntityManager().isModelEngineAvailable()) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
-                        .replace("$PLUGIN$", "ModelEngine"));
-                return;
-            }
-
-            if (!getPlugin().getCustomEntityManager().isEntityAvailable(courierType)) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
-                return;
-            }
-
-            getPlugin().getCourierSelectManager().setActiveCourier(player.getUniqueId(), courierType);
-            player.sendMessage(getMessageManager().getMessage(Message.SUCCESS_COURIER_SELECTED, true)
-                    .replace("$COURIER$", courierType.getDisplayName()));
+        CourierType courierType = CourierType.parse(args[1]);
+        if (courierType == null || !MainConfig.isCourierTypeEnabled(courierType)) {
+            player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
+            return;
+        }
+        if (!validateProvider(player, courierType)) {
             return;
         }
 
-        // /courier set <player> <entity>
-        // THIS BYPASSES THE ENABLED COURIERS CONFIG
-        if (args[0].equalsIgnoreCase("set")){
-            if (!isAdmin) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
-                return;
-            }
+        getPlugin().getCourierSelectManager().setActiveCourier(player.getUniqueId(), courierType);
+        player.sendMessage(getMessageManager().getMessage(Message.SUCCESS_COURIER_SELECTED, true)
+                .replace("$COURIER$", courierType.getDisplayName()));
+    }
 
-            if (args.length < 3) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
-                return;
-            }
-
-            Player target = Bukkit.getPlayer(args[1]);
-
-            if (target == null) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_PLAYER_NO_EXIST, true));
-                return;
-            }
-
-            CourierType courierType = CourierType.parse(args[2]);
-
-            if (courierType == null) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
-                return;
-            }
-
-            if (courierType.isMythicMobs() && !getPlugin().getCustomEntityManager().isMythicMobsAvailable()) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
-                        .replace("$PLUGIN$", "MythicMobs"));
-                return;
-            }
-
-            if (courierType.isModelEngine() && !getPlugin().getCustomEntityManager().isModelEngineAvailable()) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
-                        .replace("$PLUGIN$", "ModelEngine"));
-                return;
-            }
-
-            if (!getPlugin().getCustomEntityManager().isEntityAvailable(courierType)) {
-                player.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
-                return;
-            }
-
-            getPlugin().getCourierSelectManager().setActiveCourier(target.getUniqueId(), courierType);
-            player.sendMessage(getMessageManager().getMessage(Message.SUCCESS_COURIER_SET, true)
-                    .replace("$PLAYER$", target.getName())
-                    .replace("$COURIER$", courierType.getDisplayName()));
+    private void executeSet(CommandSender sender, String[] args) {
+        if (!sender.hasPermission("courierprime.admin")) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_NO_PERMS, true));
+            return;
+        }
+        if (args.length < 3) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
             return;
         }
 
-        player.sendMessage(getMessageManager().getMessage(Message.ERROR_UNKNOWN_ARGS, true));
+        OfflinePlayer target = resolveKnownPlayer(args[1]);
+        if (target == null) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_PLAYER_NO_EXIST, true)
+                    .replace("$PLAYER$", args[1]));
+            return;
+        }
+
+        CourierType courierType = CourierType.parse(args[2]);
+        if (courierType == null) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
+            return;
+        }
+        if (!validateProvider(sender, courierType)) {
+            return;
+        }
+
+        getPlugin().getCourierSelectManager().setActiveCourier(target.getUniqueId(), courierType);
+        sender.sendMessage(getMessageManager().getMessage(Message.SUCCESS_COURIER_SET, true)
+                .replace("$PLAYER$", target.getName())
+                .replace("$COURIER$", courierType.getDisplayName()));
+    }
+
+    private boolean validateProvider(CommandSender sender, CourierType courierType) {
+        if (courierType.isMythicMobs()
+                && !getPlugin().getCustomEntityManager().isMythicMobsAvailable()) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
+                    .replace("$PLUGIN$", "MythicMobs"));
+            return false;
+        }
+
+        if (courierType.isModelEngine()
+                && !getPlugin().getCustomEntityManager().isModelEngineAvailable()) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_PLUGIN_NOT_AVAILABLE, true)
+                    .replace("$PLUGIN$", "ModelEngine"));
+            return false;
+        }
+
+        if (!getPlugin().getCustomEntityManager().isEntityAvailable(courierType)) {
+            sender.sendMessage(getMessageManager().getMessage(Message.ERROR_ENTITY_NOT_FOUND, true));
+            return false;
+        }
+        return true;
+    }
+
+    private OfflinePlayer resolveKnownPlayer(String name) {
+        Player onlinePlayer = Bukkit.getPlayer(name);
+        if (onlinePlayer != null) {
+            return onlinePlayer;
+        }
+
+        OfflinePlayer candidate = Bukkit.getOfflinePlayer(name);
+        if (isKnownOfflinePlayer(candidate)) {
+            return candidate;
+        }
+
+        // Some server implementations return a synthetic OfflinePlayer from
+        // getOfflinePlayer(String) even when a cached player with a different
+        // case exists. Prefer the server's known-player cache in that case.
+        for (OfflinePlayer knownPlayer : Bukkit.getOfflinePlayers()) {
+            if (knownPlayer != null && knownPlayer.getName() != null
+                    && knownPlayer.getName().equalsIgnoreCase(name)
+                    && knownPlayer.hasPlayedBefore()) {
+                return knownPlayer;
+            }
+        }
+        return null;
+    }
+
+    private boolean isKnownOfflinePlayer(OfflinePlayer player) {
+        return player != null && player.getName() != null && player.hasPlayedBefore();
     }
 
     @Override
@@ -147,20 +159,41 @@ public class CourierSelectCommand extends AbstractCommand{
             return StringUtil.copyPartialMatches(args[0], Arrays.asList("select", "set"), new ArrayList<>());
         }
 
-        if (args.length == 2) {
-            if (args[0].equalsIgnoreCase("select")) {
-                return StringUtil.copyPartialMatches(args[1], MainConfig.getEnabledCourierTypeStrings(), new ArrayList<>());
+        if (args.length == 2 && args[0].equalsIgnoreCase("select")) {
+            if (!sender.hasPermission("courierprime.courier.select")) {
+                return List.of();
             }
-
-            if (args[0].equalsIgnoreCase("set")) {
-                return Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
-            }
+            return StringUtil.copyPartialMatches(args[1], MainConfig.getEnabledCourierTypeStrings(), new ArrayList<>());
         }
 
-        if (args.length == 3 && args[0].equalsIgnoreCase("set")) {
-            return StringUtil.copyPartialMatches(args[2], MainConfig.getEnabledCourierTypeStrings(), new ArrayList<>());
+        if (args.length == 2 && args[0].equalsIgnoreCase("set")) {
+            if (!sender.hasPermission("courierprime.admin")) {
+                return List.of();
+            }
+            return StringUtil.copyPartialMatches(args[1], knownPlayerNames(), new ArrayList<>());
+        }
+
+        if (args.length == 3 && args[0].equalsIgnoreCase("set")
+                && sender.hasPermission("courierprime.admin")) {
+            return StringUtil.copyPartialMatches(
+                    args[2], MainConfig.getAllSpawnableCourierTypeStrings(), new ArrayList<>());
         }
 
         return List.of();
+    }
+
+    private List<String> knownPlayerNames() {
+        Set<String> names = new LinkedHashSet<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player != null && player.getName() != null) {
+                names.add(player.getName());
+            }
+        }
+        for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            if (isKnownOfflinePlayer(player)) {
+                names.add(player.getName());
+            }
+        }
+        return new ArrayList<>(names);
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/config/ConfigManager.java
+++ b/src/main/java/com/joaorihan/courierprime/config/ConfigManager.java
@@ -4,6 +4,8 @@ import com.joaorihan.courierprime.CourierPrime;
 import com.joaorihan.courierprime.courier.Courier;
 import com.joaorihan.courierprime.courier.CourierManager;
 import lombok.*;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -69,13 +71,21 @@ public class ConfigManager {
 
         if (langFile.exists()) {
             setLanguageConfig(YamlConfiguration.loadConfiguration(langFile));
-            getPlugin().getLogger().info("Now loading " + getMainConfig().getString("lang") + " language");
+            getPlugin().getComponentLogger().info(
+                    Component.text("Now loading ", NamedTextColor.GRAY)
+                            .append(Component.text(getMainConfig().getString("lang"), NamedTextColor.AQUA))
+                            .append(Component.text(" language", NamedTextColor.GRAY))
+            );
         } else {
             File fallbackFile = new File(langFolder, "en-us.yml");
             if (fallbackFile.exists()) {
                 setLanguageConfig(YamlConfiguration.loadConfiguration(fallbackFile));
-                getPlugin().getLogger().warning(
-                        "Language file " + getMainConfig().getString("lang") + ".yml was not found; falling back to en-us."
+                getPlugin().getComponentLogger().warn(
+                        Component.text("Language file ", NamedTextColor.YELLOW)
+                                .append(Component.text(getMainConfig().getString("lang") + ".yml", NamedTextColor.GOLD))
+                                .append(Component.text(" was not found; falling back to ", NamedTextColor.YELLOW))
+                                .append(Component.text("en-us", NamedTextColor.AQUA))
+                                .append(Component.text(".", NamedTextColor.YELLOW))
                 );
             } else {
                 throw new IllegalStateException("No language file is available");

--- a/src/main/java/com/joaorihan/courierprime/config/MainConfig.java
+++ b/src/main/java/com/joaorihan/courierprime/config/MainConfig.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -51,6 +52,9 @@ public class MainConfig {
      */
     public EntityType getDefaultCourierEntityType(){
         String configuredType = config.getString("default-courier-entity-type", "VILLAGER");
+        if (configuredType == null) {
+            configuredType = "VILLAGER";
+        }
         try {
             EntityType entityType = EntityType.valueOf(configuredType.trim().toUpperCase(Locale.ROOT));
             if (entityType.isSpawnable()) {
@@ -126,7 +130,38 @@ public class MainConfig {
      * @return List of courier type strings
      */
     public List<String> getEnabledCourierTypeStrings() {
-        return config.getStringList("enabled-courier-types");
+        LinkedHashSet<String> types = new LinkedHashSet<>();
+        for (CourierType type : getEnabledCourierTypes()) {
+            types.add(type.toString());
+        }
+        return new ArrayList<>(types);
+    }
+
+    /**
+     * Checks the normal player-selection allow-list using parsed values, so
+     * case and provider-prefix normalization are handled consistently.
+     */
+    public boolean isCourierTypeEnabled(CourierType courierType) {
+        return courierType != null && getEnabledCourierTypes().contains(courierType);
+    }
+
+    /**
+     * Gets every spawnable vanilla value and every valid custom value present
+     * in the configuration. This is intended for administrator completion;
+     * administrators may assign vanilla types that are not enabled for normal
+     * player selection.
+     */
+    public List<String> getAllSpawnableCourierTypeStrings() {
+        LinkedHashSet<String> types = new LinkedHashSet<>();
+        for (EntityType entityType : EntityType.values()) {
+            if (entityType.isSpawnable()) {
+                types.add(entityType.name());
+            }
+        }
+        for (CourierType type : getEnabledCourierTypes()) {
+            types.add(type.toString());
+        }
+        return new ArrayList<>(types);
     }
 
     /**
@@ -137,6 +172,9 @@ public class MainConfig {
         if (configuredType == null) {
             // Keep the setting from the earlier custom-entities configuration layout.
             configuredType = config.getString("custom-entities.modelengine-base-entity", "ARMOR_STAND");
+        }
+        if (configuredType == null) {
+            configuredType = "ARMOR_STAND";
         }
 
         try {

--- a/src/main/java/com/joaorihan/courierprime/courier/Courier.java
+++ b/src/main/java/com/joaorihan/courierprime/courier/Courier.java
@@ -3,6 +3,7 @@ package com.joaorihan.courierprime.courier;
 import com.joaorihan.courierprime.CourierPrime;
 import com.joaorihan.courierprime.config.MainConfig;
 import com.joaorihan.courierprime.config.Message;
+import com.joaorihan.courierprime.integration.CustomEntityManager;
 import lombok.Getter;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -11,64 +12,84 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
+import java.util.logging.Level;
+
+/**
+ * Represents one courier delivery attempt for one player.
+ */
 @Getter
 public class Courier {
 
-    // Getters for accessing private fields.
     private Entity courier;
     private final Player recipient;
     private boolean delivered;
+    private boolean deliveryInProgress;
+    private boolean retired;
+    private BukkitTask movementTask;
+    private BukkitTask timeoutTask;
+    private BukkitTask replacementTask;
 
-    private static final CourierPrime plugin = CourierPrime.getPlugin();
-
-    /**
-     * Constructs a Courier for the given player and immediately spawns the courier entity.
-     *
-     * @param recipient The player who will receive the courier.
-     */
     public Courier(Player recipient) {
         this.recipient = recipient;
         this.delivered = false;
+        this.deliveryInProgress = false;
         spawn();
     }
 
     /**
-     * Spawns the courier entity and sets up its behavior.
+     * Spawns the selected courier and sets up its behavior. Entity work is
+     * performed synchronously on the Bukkit thread.
      */
     private void spawn() {
-
-        if (!CourierManager.canSpawn(recipient)) return;
-
-        // Determine spawn location based on player's location and direction.
-        Location loc = recipient.getLocation()
-                .add(recipient.getLocation().getDirection().setY(0).multiply(MainConfig.getSpawnDistance()));
-
-        // Get player's selected courier type
-        CourierType courierType = plugin.getCourierSelectManager().getActiveCourier(recipient.getUniqueId());
-
-        if (courierType != null && !courierType.isVanilla()) {
-            // Try to spawn custom entity (MythicMobs/ModelEngine)
-            courier = plugin.getCustomEntityManager().spawnEntity(courierType, loc);
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin == null || !CourierManager.canSpawn(recipient)) {
+            return;
         }
 
-        // Fall back to vanilla entity if custom entity spawning failed or no custom type selected
-        if (courier == null) {
-            EntityType vanillaType = (courierType != null && courierType.isVanilla())
-                    ? courierType.getVanillaType()
+        Location recipientLocation = recipient.getLocation();
+        Location location = recipientLocation.clone().add(
+                recipientLocation.getDirection().setY(0).multiply(MainConfig.getSpawnDistance()));
+
+        CourierType selectedType = plugin.getCourierSelectManager() == null
+                ? null
+                : plugin.getCourierSelectManager().getActiveCourier(recipient.getUniqueId());
+
+        if (selectedType != null && !selectedType.isVanilla()) {
+            CustomEntityManager customEntityManager = plugin.getCustomEntityManager();
+            // This availability check is intentionally before spawnEntity:
+            // unavailable or unknown saved custom selections must fall back to
+            // vanilla without reaching an optional provider spawn call.
+            if (customEntityManager != null && customEntityManager.isEntityAvailable(selectedType)) {
+                courier = customEntityManager.spawnEntity(selectedType, location);
+            }
+        }
+
+        if (!CourierManager.isLiveEntity(courier)) {
+            removeSpawnedEntity();
+            EntityType vanillaType = selectedType != null && selectedType.isVanilla()
+                    ? selectedType.getVanillaType()
                     : MainConfig.getDefaultCourierEntityType();
-            courier = recipient.getWorld().spawnEntity(loc, vanillaType);
+            courier = spawnVanilla(location, vanillaType);
+
+            if (!CourierManager.isLiveEntity(courier)) {
+                removeSpawnedEntity();
+                EntityType defaultType = MainConfig.getDefaultCourierEntityType();
+                if (vanillaType != defaultType) {
+                    courier = spawnVanilla(location, defaultType);
+                }
+            }
         }
 
-        if (courier == null) {
+        if (!CourierManager.isLiveEntity(courier)) {
+            removeSpawnedEntity();
             plugin.getLogger().warning("Unable to spawn a courier for " + recipient.getName());
             return;
         }
 
-        // Register this courier in the manager.
         CourierManager.getActiveCouriers().put(courier, this);
 
-        // Configure the courier entity.
         courier.setCustomName(plugin.getMessageManager().getMessage(Message.COURIER_NAME)
                 .replace("$PLAYER$", recipient.getName()));
         courier.setCustomNameVisible(false);
@@ -76,19 +97,23 @@ public class Courier {
         recipient.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_COURIER_ARRIVED, true));
         courier.getWorld().playSound(courier.getLocation(), Sound.UI_TOAST_IN, 1, 1);
 
-        // Runnable to adjust courier movement.
-        new BukkitRunnable() {
+        movementTask = new BukkitRunnable() {
             @Override
             public void run() {
-                if (courier.isDead()) {
-                    CourierManager.getActiveCouriers().remove(courier);
-                    scheduleReplacement();
+                if (retired) {
+                    cancel();
+                    return;
+                }
+                if (!CourierManager.isLiveEntity(courier)) {
+                    retire(false, true);
                     cancel();
                     return;
                 }
 
                 courier.setFallDistance(0);
-                if (courier.isOnGround() && courier.getWorld() == recipient.getWorld()) {
+                if (courier.isOnGround()
+                        && courier.getWorld() != null
+                        && courier.getWorld().equals(recipient.getWorld())) {
                     courier.teleport(courier.getLocation().setDirection(
                             recipient.getLocation().subtract(courier.getLocation()).toVector()));
                     if (courier instanceof LivingEntity livingEntity) {
@@ -96,51 +121,172 @@ public class Courier {
                     }
                 }
             }
-        }.runTaskTimer(plugin, 0, 1);
+        }.runTaskTimer(plugin, 0L, 1L);
 
-        // Runnable to remove the courier after a delay.
-        new BukkitRunnable() {
+        timeoutTask = new BukkitRunnable() {
             @Override
             public void run() {
-                if (!courier.isDead()) {
-                    remove();
-
-                    if (recipient.isOnline() && !delivered) {
-                        recipient.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_IGNORED, true));
-                    }
-                    courier.getWorld().playSound(courier.getLocation(), Sound.UI_TOAST_OUT, 1, 1);
-
-                    // Schedule a new courier spawn after a resend delay.
-                    scheduleReplacement();
+                if (retired) {
+                    cancel();
+                    return;
                 }
+                if (!CourierManager.isLiveEntity(courier)) {
+                    retire(false, true);
+                    cancel();
+                    return;
+                }
+
+                if (!delivered && hasPendingMail() && recipient.isOnline()) {
+                    recipient.sendMessage(plugin.getMessageManager().getMessage(Message.SUCCESS_IGNORED, true));
+                }
+                courier.getWorld().playSound(courier.getLocation(), Sound.UI_TOAST_OUT, 1, 1);
+                retire(true, !delivered);
+                cancel();
             }
-        }.runTaskLater(plugin, MainConfig.getRemoveDelay());
+        }.runTaskLater(plugin, Math.max(0L, MainConfig.getRemoveDelay()));
+    }
+
+    private Entity spawnVanilla(Location location, EntityType type) {
+        if (type == null || !type.isSpawnable()) {
+            return null;
+        }
+        try {
+            return location.getWorld().spawnEntity(location, type);
+        } catch (RuntimeException e) {
+            CourierPrime plugin = CourierPrime.getPlugin();
+            if (plugin != null) {
+                plugin.getLogger().warning(
+                        "Unable to spawn vanilla courier type " + type.name() + "; trying the default type."
+                );
+            }
+            return null;
+        }
+    }
+
+    private void removeSpawnedEntity() {
+        if (courier != null && !courier.isDead()) {
+            courier.remove();
+        }
+        courier = null;
+    }
+
+    private boolean hasPendingMail() {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        return plugin != null && plugin.getOutgoingManager() != null
+                && plugin.getOutgoingManager().getOutgoing() != null
+                && plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId()) != null
+                && !plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId()).isEmpty();
+    }
+
+    /**
+     * Removes the courier entity without scheduling a replacement. Reload and
+     * shutdown own their pending-mail rescheduling contract.
+     */
+    public void remove() {
+        retire(true, false);
+    }
+
+    /**
+     * Marks the delivery as completed. A completed courier is only cleaned up
+     * by its timeout and can never emit the ignored message or schedule a
+     * replacement.
+     */
+    public void setDelivered() {
+        if (retired || delivered || hasPendingMail()) {
+            return;
+        }
+        delivered = true;
+        deliveryInProgress = false;
+        if (replacementTask != null) {
+            replacementTask.cancel();
+            replacementTask = null;
+        }
+        if (courier != null) {
+            courier.setCustomName(CourierPrime.getPlugin().getMessageManager()
+                    .getMessage(Message.COURIER_NAME_RECEIVED));
+        }
+    }
+
+    /**
+     * Claims the courier for one click-delivery attempt. All entity events run
+     * on the Bukkit thread, but the guard also handles synchronous re-entry
+     * from inventory or plugin callbacks.
+     *
+     * @return true when this click may call LetterSender.receive
+     */
+    public boolean beginDelivery() {
+        if (retired || delivered || deliveryInProgress) {
+            return false;
+        }
+        deliveryInProgress = true;
+        return true;
+    }
+
+    /**
+     * Finishes a receive attempt after LetterSender has transferred as much
+     * mail as it can. The courier is completed only when no pending mail
+     * remains for its recipient.
+     *
+     * @return true when the courier is now fully delivered
+     */
+    public boolean completeDeliveryAttempt() {
+        deliveryInProgress = false;
+        if (retired || hasPendingMail()) {
+            return false;
+        }
+        setDelivered();
+        return delivered;
+    }
+
+    private void retire(boolean removeEntity, boolean retry) {
+        if (retired) {
+            return;
+        }
+        retired = true;
+        deliveryInProgress = false;
+
+        if (movementTask != null) {
+            movementTask.cancel();
+            movementTask = null;
+        }
+        if (timeoutTask != null) {
+            timeoutTask.cancel();
+            timeoutTask = null;
+        }
+
+        Entity oldCourier = courier;
+        if (oldCourier != null) {
+            CourierManager.getActiveCouriers().remove(oldCourier);
+            if (removeEntity && !oldCourier.isDead()) {
+                oldCourier.remove();
+            }
+        }
+        courier = null;
+
+        if (retry && !delivered) {
+            scheduleReplacement();
+        }
     }
 
     private void scheduleReplacement() {
-        new BukkitRunnable() {
+        if (delivered || !hasPendingMail() || !recipient.isOnline()) {
+            return;
+        }
+
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin == null) {
+            return;
+        }
+
+        replacementTask = new BukkitRunnable() {
             @Override
             public void run() {
+                replacementTask = null;
+                if (!recipient.isOnline() || !hasPendingMail()) {
+                    return;
+                }
                 new Courier(recipient);
             }
-        }.runTaskLater(plugin, MainConfig.getResendDelay());
+        }.runTaskLater(plugin, Math.max(0L, MainConfig.getResendDelay()));
     }
-
-    /**
-     * Removes the courier entity from the world and unregisters it.
-     */
-    public void remove() {
-        if (courier == null) return;
-        CourierManager.getActiveCouriers().remove(courier);
-        courier.remove();
-    }
-
-    /**
-     * Marks the courier as having delivered its mail.
-     */
-    public void setDelivered() {
-        delivered = true;
-        courier.setCustomName(plugin.getMessageManager().getMessage(Message.COURIER_NAME_RECEIVED));
-    }
-
 }

--- a/src/main/java/com/joaorihan/courierprime/courier/CourierManager.java
+++ b/src/main/java/com/joaorihan/courierprime/courier/CourierManager.java
@@ -9,35 +9,41 @@ import org.bukkit.entity.Player;
 import org.bukkit.metadata.MetadataValue;
 
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class CourierManager {
 
-    private static final CourierPrime plugin = CourierPrime.getPlugin();
-
-    // Tracks active courier instances (keyed by the spawned entity)
+    // Tracks active courier instances (keyed by the spawned entity).
     @Getter
     private static final HashMap<Entity, Courier> activeCouriers = new HashMap<>();
 
     /**
-     * Checks whether a courier can be spawned for the given player.
-     *
-     * @param recipient The player to check.
-     * @return true if allowed; false otherwise.
+     * Checks whether a courier can be spawned for the given player. All calls
+     * are expected on the Bukkit main thread because entity state is queried
+     * and the active map is cleaned here.
      */
     public static boolean canSpawn(Player recipient) {
-        if (!recipient.isOnline()
-                || !plugin.getOutgoingManager().getOutgoing().containsKey(recipient.getUniqueId())
-                || plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId()).isEmpty()) {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (recipient == null || plugin == null || !recipient.isOnline()) {
             return false;
         }
 
-        activeCouriers.entrySet().removeIf(entry -> entry.getKey() == null
-                || entry.getValue() == null
-                || entry.getKey().isDead());
-        for (Courier courier : activeCouriers.values()) {
-            if (courier.getRecipient().getUniqueId().equals(recipient.getUniqueId())
-                    && courier.getCourier() != null
-                    && !courier.getCourier().isDead()) {
+        cleanupStaleCouriers();
+
+        if (plugin.getOutgoingManager() == null
+                || !hasPendingMail(plugin, recipient.getUniqueId())) {
+            return false;
+        }
+
+        // The map is keyed by entities, so explicitly compare recipients to
+        // prevent a second live courier from being created for the same UUID.
+        for (Map.Entry<Entity, Courier> entry : activeCouriers.entrySet()) {
+            Entity entity = entry.getKey();
+            Courier courier = entry.getValue();
+            if (courier != null && courier.getRecipient() != null
+                    && courier.getRecipient().getUniqueId().equals(recipient.getUniqueId())
+                    && isLiveEntity(entity)) {
                 return false;
             }
         }
@@ -59,11 +65,40 @@ public class CourierManager {
             return false;
         }
 
-        if (plugin.getLetterManager().isInBlockedMode(recipient)) {
+        if (plugin.getLetterManager() != null && plugin.getLetterManager().isInBlockedMode(recipient)) {
             recipient.sendMessage(plugin.getMessageManager().getMessage(Message.ERROR_IN_BLOCKED_MODE, true));
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Returns whether an entity is still available for interaction. This
+     * deliberately works for both living and non-living Bukkit entities.
+     */
+    static boolean isLiveEntity(Entity entity) {
+        return entity != null && !entity.isDead() && entity.isValid();
+    }
+
+    private static void cleanupStaleCouriers() {
+        Iterator<Map.Entry<Entity, Courier>> iterator = activeCouriers.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Entity, Courier> entry = iterator.next();
+            Entity entity = entry.getKey();
+            Courier courier = entry.getValue();
+            if (courier == null || !isLiveEntity(entity)) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static boolean hasPendingMail(CourierPrime plugin, java.util.UUID recipient) {
+        if (plugin.getOutgoingManager() == null
+                || plugin.getOutgoingManager().getOutgoing() == null) {
+            return false;
+        }
+        var letters = plugin.getOutgoingManager().getOutgoing().get(recipient);
+        return letters != null && !letters.isEmpty();
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/courier/CourierSelectManager.java
+++ b/src/main/java/com/joaorihan/courierprime/courier/CourierSelectManager.java
@@ -3,6 +3,7 @@ package com.joaorihan.courierprime.courier;
 import com.joaorihan.courierprime.config.ConfigManager;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class CourierSelectManager {
@@ -17,20 +18,53 @@ public class CourierSelectManager {
     }
 
     protected void loadActiveCouriers(){
-        activeCourierTypes.clear();
-        configManager.getCourierSelectConfig().getValues(false).forEach((s, o) -> {
-            CourierType type = CourierType.parse(o.toString());
+        if (configManager == null || configManager.getCourierSelectConfig() == null) {
+            return;
+        }
+
+        Map<String, Object> storedCouriers;
+        try {
+            storedCouriers = configManager.getCourierSelectConfig().getValues(false);
+        } catch (RuntimeException e) {
+            configManager.getPlugin().getLogger().warning(
+                    "Unable to read couriers.yml entries; keeping the file unchanged and using defaults."
+            );
+            return;
+        }
+
+        HashMap<UUID, CourierType> loadedCouriers = new HashMap<>();
+        storedCouriers.forEach((playerId, storedValue) -> {
+            if (storedValue == null) {
+                configManager.getPlugin().getLogger().warning(
+                        "Ignoring empty courier type for player " + playerId + " in couriers.yml."
+                );
+                return;
+            }
+
+            CourierType type;
+            try {
+                type = CourierType.parse(storedValue.toString());
+            } catch (RuntimeException e) {
+                type = null;
+            }
             if (type == null) {
-                configManager.getPlugin().getLogger().warning("Invalid courier type for player " + s + ": " + o);
+                configManager.getPlugin().getLogger().warning(
+                        "Invalid courier type for player " + playerId + ": " + storedValue
+                );
                 return;
             }
 
             try {
-                activeCourierTypes.put(UUID.fromString(s), type);
+                loadedCouriers.put(UUID.fromString(playerId), type);
             } catch (IllegalArgumentException e) {
-                configManager.getPlugin().getLogger().warning("Invalid player UUID in couriers.yml: " + s);
+                configManager.getPlugin().getLogger().warning(
+                        "Invalid player UUID in couriers.yml: " + playerId
+                );
             }
         });
+
+        activeCourierTypes.clear();
+        activeCourierTypes.putAll(loadedCouriers);
     }
 
     public CourierType getActiveCourier(UUID player){
@@ -38,6 +72,9 @@ public class CourierSelectManager {
     }
 
     public void setActiveCourier(UUID player, CourierType courierType){
+        if (player == null || courierType == null) {
+            return;
+        }
         configManager.getCourierSelectConfig().set(String.valueOf(player), courierType.toString());
         activeCourierTypes.put(player, courierType);
         configManager.saveCourierConfig();

--- a/src/main/java/com/joaorihan/courierprime/courier/CourierType.java
+++ b/src/main/java/com/joaorihan/courierprime/courier/CourierType.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.bukkit.entity.EntityType;
 
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Represents a courier type that can be either a vanilla EntityType or a custom entity
@@ -11,6 +12,9 @@ import java.util.Locale;
  */
 @Getter
 public class CourierType {
+
+    private static final Pattern CUSTOM_IDENTIFIER =
+            Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]*");
 
     public enum Provider {
         VANILLA,
@@ -53,14 +57,14 @@ public class CourierType {
         // MythicMobs format: mm:MOB_ID
         if (lower.startsWith("mm:")) {
             String mobId = normalized.substring(3).trim();
-            if (mobId.isEmpty()) return null;
+            if (!isValidCustomIdentifier(mobId)) return null;
             return new CourierType(Provider.MYTHICMOBS, mobId, null);
         }
 
         // ModelEngine format: meg:MODEL_ID
         if (lower.startsWith("meg:")) {
             String modelId = normalized.substring(4).trim();
-            if (modelId.isEmpty()) return null;
+            if (!isValidCustomIdentifier(modelId)) return null;
             return new CourierType(Provider.MODELENGINE, modelId, null);
         }
 
@@ -75,6 +79,16 @@ public class CourierType {
         } catch (IllegalArgumentException e) {
             return null;
         }
+    }
+
+    /**
+     * Checks whether an identifier is safe to pass to an optional entity
+     * provider. Provider identifiers are deliberately kept narrower than a
+     * free-form command argument so malformed configuration cannot become an
+     * API lookup or spawn request.
+     */
+    public static boolean isValidCustomIdentifier(String identifier) {
+        return identifier != null && CUSTOM_IDENTIFIER.matcher(identifier.trim()).matches();
     }
 
     /**

--- a/src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java
+++ b/src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java
@@ -2,6 +2,8 @@ package com.joaorihan.courierprime.integration;
 
 import com.joaorihan.courierprime.CourierPrime;
 import com.joaorihan.courierprime.courier.CourierType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
@@ -23,13 +25,27 @@ public class CustomEntityManager {
      */
     public void initialize() {
         if (mythicMobsProvider.isAvailable()) {
-            CourierPrime.getPlugin().getLogger().info("MythicMobs detected - custom mm: couriers enabled!");
+            CourierPrime.getPlugin().getComponentLogger().info(
+                    Component.text("Hooked into ", NamedTextColor.GRAY)
+                            .append(Component.text("MythicMobs", NamedTextColor.GOLD))
+                            .append(Component.text(" - custom ", NamedTextColor.GRAY))
+                            .append(Component.text("mm:", NamedTextColor.GOLD))
+                            .append(Component.text(" couriers enabled!", NamedTextColor.GREEN))
+            );
         }
         if (modelEngineProvider.isAvailable()) {
-            CourierPrime.getPlugin().getLogger().info("ModelEngine detected - custom meg: couriers enabled!");
+            CourierPrime.getPlugin().getComponentLogger().info(
+                    Component.text("Hooked into ", NamedTextColor.GRAY)
+                            .append(Component.text("ModelEngine", NamedTextColor.AQUA))
+                            .append(Component.text(" - custom ", NamedTextColor.GRAY))
+                            .append(Component.text("meg:", NamedTextColor.AQUA))
+                            .append(Component.text(" couriers enabled!", NamedTextColor.GREEN))
+            );
         }
         if (!mythicMobsProvider.isAvailable() && !modelEngineProvider.isAvailable()) {
-            CourierPrime.getPlugin().getLogger().info("No custom entity plugins detected. Only vanilla couriers available.");
+            CourierPrime.getPlugin().getComponentLogger().info(
+                    Component.text("No custom courier plugins hooked; vanilla couriers only.", NamedTextColor.GRAY)
+            );
         }
     }
 

--- a/src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java
+++ b/src/main/java/com/joaorihan/courierprime/integration/CustomEntityManager.java
@@ -4,27 +4,39 @@ import com.joaorihan.courierprime.CourierPrime;
 import com.joaorihan.courierprime.courier.CourierType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
+import java.util.logging.Level;
+
 /**
- * Manages custom entity providers and handles spawning logic
+ * Manages optional custom entity providers and handles their lifecycle.
+ *
+ * Provider classes are created lazily, after their corresponding Bukkit
+ * plugin is enabled. This keeps an absent soft dependency from resolving its
+ * compile-only API during normal vanilla startup.
  */
 public class CustomEntityManager {
 
-    private final MythicMobsProvider mythicMobsProvider;
-    private final ModelEngineProvider modelEngineProvider;
+    private static final String MYTHICMOBS = "MythicMobs";
+    private static final String MODELENGINE = "ModelEngine";
 
-    public CustomEntityManager() {
-        mythicMobsProvider = new MythicMobsProvider();
-        modelEngineProvider = new ModelEngineProvider();
-    }
+    private CustomEntityProvider mythicMobsProvider;
+    private CustomEntityProvider modelEngineProvider;
+    private boolean mythicMobsLinkageFailure;
+    private boolean modelEngineLinkageFailure;
 
     /**
-     * Initializes the manager and logs available providers
+     * Initializes the manager and logs available providers. Calling this more
+     * than once is safe; provider instances are reused while the manager is
+     * alive.
      */
     public void initialize() {
-        if (mythicMobsProvider.isAvailable()) {
+        boolean mythicMobsAvailable = isMythicMobsAvailable();
+        boolean modelEngineAvailable = isModelEngineAvailable();
+
+        if (mythicMobsAvailable) {
             CourierPrime.getPlugin().getComponentLogger().info(
                     Component.text("Hooked into ", NamedTextColor.GRAY)
                             .append(Component.text("MythicMobs", NamedTextColor.GOLD))
@@ -33,7 +45,7 @@ public class CustomEntityManager {
                             .append(Component.text(" couriers enabled!", NamedTextColor.GREEN))
             );
         }
-        if (modelEngineProvider.isAvailable()) {
+        if (modelEngineAvailable) {
             CourierPrime.getPlugin().getComponentLogger().info(
                     Component.text("Hooked into ", NamedTextColor.GRAY)
                             .append(Component.text("ModelEngine", NamedTextColor.AQUA))
@@ -42,7 +54,7 @@ public class CustomEntityManager {
                             .append(Component.text(" couriers enabled!", NamedTextColor.GREEN))
             );
         }
-        if (!mythicMobsProvider.isAvailable() && !modelEngineProvider.isAvailable()) {
+        if (!mythicMobsAvailable && !modelEngineAvailable) {
             CourierPrime.getPlugin().getComponentLogger().info(
                     Component.text("No custom courier plugins hooked; vanilla couriers only.", NamedTextColor.GRAY)
             );
@@ -50,57 +62,176 @@ public class CustomEntityManager {
     }
 
     public boolean isMythicMobsAvailable() {
-        return mythicMobsProvider.isAvailable();
+        if (!isPluginEnabled(MYTHICMOBS)) {
+            return false;
+        }
+        return providerAvailable(getMythicMobsProvider(), true);
     }
 
     public boolean isModelEngineAvailable() {
-        return modelEngineProvider.isAvailable();
-    }
-
-    public boolean isEntityAvailable(CourierType courierType) {
-        if (courierType == null || courierType.isVanilla()) {
-            return courierType != null;
+        if (!isPluginEnabled(MODELENGINE)) {
+            return false;
         }
-        if (courierType.isMythicMobs()) {
-            return mythicMobsProvider.hasEntity(courierType.getIdentifier());
-        }
-        if (courierType.isModelEngine()) {
-            return modelEngineProvider.hasEntity(courierType.getIdentifier());
-        }
-        return false;
+        return providerAvailable(getModelEngineProvider(), false);
     }
 
     /**
-     * Spawns a custom entity based on the CourierType
-     * @param courierType The courier type to spawn
-     * @param location The spawn location
-     * @return The spawned entity, or null if spawning failed
+     * Validates both the provider availability and the provider-side
+     * identifier. A missing dependency or type is intentionally reported as
+     * unavailable so saved selections can fall back to vanilla at spawn time.
+     */
+    public boolean isEntityAvailable(CourierType courierType) {
+        if (courierType == null) {
+            return false;
+        }
+        if (courierType.isVanilla()) {
+            return courierType.getVanillaType() != null
+                    && courierType.getVanillaType().isSpawnable();
+        }
+        if (!CourierType.isValidCustomIdentifier(courierType.getIdentifier())) {
+            return false;
+        }
+
+        return switch (courierType.getProvider()) {
+            case MYTHICMOBS -> hasEntity(getMythicMobsProvider(), true, courierType.getIdentifier());
+            case MODELENGINE -> hasEntity(getModelEngineProvider(), false, courierType.getIdentifier());
+            case VANILLA -> false;
+        };
+    }
+
+    /**
+     * Spawns a custom entity based on the CourierType.
+     *
+     * @param courierType the courier type to spawn
+     * @param location the spawn location
+     * @return the spawned entity, or null if spawning failed
      */
     public Entity spawnEntity(CourierType courierType, Location location) {
-        if (courierType == null || courierType.isVanilla()) {
+        if (courierType == null || courierType.isVanilla() || location == null
+                || location.getWorld() == null
+                || !CourierType.isValidCustomIdentifier(courierType.getIdentifier())) {
             return null;
         }
 
-        if (courierType.isMythicMobs()) {
-            if (!mythicMobsProvider.isAvailable()) {
-                CourierPrime.getPlugin().getLogger().warning(
-                    "Attempted to spawn MythicMobs courier but MythicMobs is not installed!"
-                );
-                return null;
-            }
-            return mythicMobsProvider.spawnEntity(courierType.getIdentifier(), location);
+        boolean mythicMobs = courierType.isMythicMobs();
+        CustomEntityProvider provider = mythicMobs
+                ? getMythicMobsProvider()
+                : getModelEngineProvider();
+        if (!providerAvailable(provider, mythicMobs)) {
+            return null;
         }
 
-        if (courierType.isModelEngine()) {
-            if (!modelEngineProvider.isAvailable()) {
-                CourierPrime.getPlugin().getLogger().warning(
-                    "Attempted to spawn ModelEngine courier but ModelEngine is not installed!"
-                );
+        String identifier = courierType.getIdentifier();
+        try {
+            // Revalidate immediately before spawning. This protects callers
+            // that invoke spawnEntity directly and ensures unknown IDs never
+            // reach the provider's spawn method.
+            if (!provider.hasEntity(identifier)) {
                 return null;
             }
-            return modelEngineProvider.spawnEntity(courierType.getIdentifier(), location);
+            return provider.spawnEntity(identifier, location);
+        } catch (LinkageError e) {
+            markLinkageFailure(mythicMobs, e);
+            return null;
+        } catch (RuntimeException e) {
+            logger().log(Level.WARNING,
+                    "The " + provider.getName() + " provider failed while spawning '"
+                            + identifier + "'. Falling back to a vanilla courier.", e);
+            return null;
+        }
+    }
+
+    private boolean hasEntity(CustomEntityProvider provider, boolean mythicMobs, String identifier) {
+        if (!isPluginEnabled(mythicMobs ? MYTHICMOBS : MODELENGINE)
+                || !CourierType.isValidCustomIdentifier(identifier)
+                || !providerAvailable(provider, mythicMobs)) {
+            return false;
         }
 
-        return null;
+        try {
+            return provider.hasEntity(identifier);
+        } catch (LinkageError e) {
+            markLinkageFailure(mythicMobs, e);
+            return false;
+        } catch (RuntimeException e) {
+            logger().log(Level.WARNING,
+                    "The " + provider.getName() + " provider could not validate '"
+                            + identifier + "'.", e);
+            return false;
+        }
+    }
+
+    private boolean providerAvailable(CustomEntityProvider provider, boolean mythicMobs) {
+        if (provider == null) {
+            return false;
+        }
+        try {
+            return provider.isAvailable();
+        } catch (LinkageError e) {
+            markLinkageFailure(mythicMobs, e);
+            return false;
+        } catch (RuntimeException e) {
+            logger().log(Level.WARNING,
+                    "The " + provider.getName() + " provider could not be queried.", e);
+            return false;
+        }
+    }
+
+    private CustomEntityProvider getMythicMobsProvider() {
+        if (!isPluginEnabled(MYTHICMOBS) || mythicMobsLinkageFailure) {
+            return null;
+        }
+        if (mythicMobsProvider == null) {
+            try {
+                mythicMobsProvider = new MythicMobsProvider();
+            } catch (LinkageError e) {
+                markLinkageFailure(true, e);
+            }
+        }
+        return mythicMobsProvider;
+    }
+
+    private CustomEntityProvider getModelEngineProvider() {
+        if (!isPluginEnabled(MODELENGINE) || modelEngineLinkageFailure) {
+            return null;
+        }
+        if (modelEngineProvider == null) {
+            try {
+                modelEngineProvider = new ModelEngineProvider();
+            } catch (LinkageError e) {
+                markLinkageFailure(false, e);
+            }
+        }
+        return modelEngineProvider;
+    }
+
+    private boolean isPluginEnabled(String pluginName) {
+        return Bukkit.getPluginManager() != null
+                && Bukkit.getPluginManager().isPluginEnabled(pluginName);
+    }
+
+    private void markLinkageFailure(boolean mythicMobs, LinkageError error) {
+        if (mythicMobs) {
+            if (mythicMobsLinkageFailure) {
+                return;
+            }
+            mythicMobsLinkageFailure = true;
+        } else {
+            if (modelEngineLinkageFailure) {
+                return;
+            }
+            modelEngineLinkageFailure = true;
+        }
+
+        String provider = mythicMobs ? MYTHICMOBS : MODELENGINE;
+        logger().log(Level.WARNING,
+                provider + " is enabled but its optional API could not be linked. "
+                        + "That courier provider will remain disabled until the plugin is reloaded.",
+                error);
+    }
+
+    private java.util.logging.Logger logger() {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        return plugin == null ? java.util.logging.Logger.getLogger("CourierPrime") : plugin.getLogger();
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/integration/CustomEntityProvider.java
+++ b/src/main/java/com/joaorihan/courierprime/integration/CustomEntityProvider.java
@@ -21,6 +21,16 @@ public interface CustomEntityProvider {
     boolean isAvailable();
 
     /**
+     * Checks whether a provider-side identifier exists before a spawn is
+     * attempted. Providers should override this with their native registry
+     * lookup; the default keeps third-party implementations source-compatible
+     * while still refusing an empty identifier.
+     */
+    default boolean hasEntity(String entityId) {
+        return entityId != null && !entityId.trim().isEmpty();
+    }
+
+    /**
      * Spawns a custom entity at the given location
      * @param entityId The custom entity/mob ID
      * @param location The spawn location
@@ -29,4 +39,3 @@ public interface CustomEntityProvider {
     Entity spawnEntity(String entityId, Location location);
 
 }
-

--- a/src/main/java/com/joaorihan/courierprime/integration/ModelEngineProvider.java
+++ b/src/main/java/com/joaorihan/courierprime/integration/ModelEngineProvider.java
@@ -1,18 +1,20 @@
 package com.joaorihan.courierprime.integration;
 
-import com.joaorihan.courierprime.CourierPrime;
-import com.joaorihan.courierprime.config.MainConfig;
 import com.ticxo.modelengine.api.ModelEngineAPI;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
+import com.joaorihan.courierprime.CourierPrime;
+import com.joaorihan.courierprime.config.MainConfig;
+import com.joaorihan.courierprime.courier.CourierType;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
+import java.util.Optional;
 import java.util.logging.Level;
 
 /**
- * Custom entity provider for ModelEngine integration
+ * Custom entity provider for ModelEngine integration.
  */
 public class ModelEngineProvider implements CustomEntityProvider {
 
@@ -25,46 +27,128 @@ public class ModelEngineProvider implements CustomEntityProvider {
 
     @Override
     public boolean isAvailable() {
-        return Bukkit.getPluginManager().isPluginEnabled(PLUGIN_NAME);
+        return Bukkit.getPluginManager() != null
+                && Bukkit.getPluginManager().isPluginEnabled(PLUGIN_NAME);
     }
 
+    @Override
     public boolean hasEntity(String entityId) {
-        return isAvailable() && ModelEngineAPI.getBlueprint(entityId) != null;
+        if (!isAvailable() || !CourierType.isValidCustomIdentifier(entityId)) {
+            return false;
+        }
+
+        try {
+            return ModelEngineAPI.getBlueprint(entityId) != null;
+        } catch (LinkageError e) {
+            logger().log(Level.WARNING, "ModelEngine API could not validate courier model '" + entityId + "'.", e);
+            return false;
+        } catch (RuntimeException e) {
+            logger().log(Level.WARNING, "ModelEngine could not validate courier model '" + entityId + "'.", e);
+            return false;
+        }
     }
 
     @Override
     public Entity spawnEntity(String entityId, Location location) {
-        if (!isAvailable()) {
+        if (!isAvailable() || location == null || location.getWorld() == null
+                || !CourierType.isValidCustomIdentifier(entityId) || !hasEntity(entityId)) {
             return null;
         }
 
         Entity baseEntity = null;
+        ModeledEntity modeledEntity = null;
+        ActiveModel model = null;
         try {
-            // Spawn the base entity first
+            // Spawn the configured host first. Every later failure path below
+            // removes it, including a provider API returning null/empty.
             baseEntity = location.getWorld().spawnEntity(location, MainConfig.getModelEngineBaseEntity());
-
-            // Create and attach the model
-            ActiveModel model = ModelEngineAPI.createActiveModel(entityId);
-            if (model == null) {
-                CourierPrime.getPlugin().getLogger().warning(
-                    "ModelEngine model '" + entityId + "' not found! Falling back to vanilla entity."
-                );
-                baseEntity.remove();
+            if (baseEntity == null || baseEntity.isDead()) {
+                cleanup(baseEntity, modeledEntity, model);
                 return null;
             }
 
-            ModeledEntity modeledEntity = ModelEngineAPI.createModeledEntity(baseEntity);
-            modeledEntity.addModel(model, true);
+            model = ModelEngineAPI.createActiveModel(entityId);
+            if (model == null) {
+                warn("ModelEngine model '" + entityId + "' could not be created.");
+                cleanup(baseEntity, modeledEntity, model);
+                return null;
+            }
+
+            modeledEntity = ModelEngineAPI.createModeledEntity(baseEntity);
+            if (modeledEntity == null) {
+                warn("ModelEngine could not create a modeled host for '" + entityId + "'.");
+                cleanup(baseEntity, modeledEntity, model);
+                return null;
+            }
+
+            Optional<ActiveModel> attachedModel = modeledEntity.addModel(model, true);
+            boolean modelAttached = attachedModel != null && attachedModel.isPresent();
+            if (!modelAttached && modeledEntity.getModels() != null) {
+                // R4 providers have used the Optional return value both for
+                // add success and for a replaced model across API revisions;
+                // the model registry is the stable confirmation of an attach.
+                modelAttached = modeledEntity.getModels().containsValue(model);
+            }
+            if (!modelAttached) {
+                warn("ModelEngine could not attach model '" + entityId + "'.");
+                cleanup(baseEntity, modeledEntity, model);
+                return null;
+            }
 
             return baseEntity;
-
+        } catch (LinkageError e) {
+            cleanup(baseEntity, modeledEntity, model);
+            logger().log(Level.WARNING,
+                    "ModelEngine's optional API could not attach courier model '" + entityId + "'.", e);
+            return null;
         } catch (Exception e) {
-            if (baseEntity != null && !baseEntity.isDead()) {
-                baseEntity.remove();
-            }
-            CourierPrime.getPlugin().getLogger().log(Level.WARNING,
-                "Failed to spawn ModelEngine entity '" + entityId + "': " + e.getMessage(), e);
+            cleanup(baseEntity, modeledEntity, model);
+            logger().log(Level.WARNING,
+                    "Failed to spawn ModelEngine courier '" + entityId
+                            + "'; the host entity was cleaned up.", e);
             return null;
         }
+    }
+
+    private void cleanup(Entity baseEntity, ModeledEntity modeledEntity, ActiveModel model) {
+        if (model != null) {
+            try {
+                model.destroy();
+            } catch (LinkageError | RuntimeException ignored) {
+                // Continue cleanup of the modeled record and Bukkit host.
+            }
+        }
+
+        if (modeledEntity != null) {
+            try {
+                modeledEntity.destroy();
+            } catch (LinkageError | RuntimeException ignored) {
+                // Continue cleanup of the Bukkit host.
+            }
+        }
+
+        if (baseEntity != null) {
+            try {
+                ModelEngineAPI.removeModeledEntity(baseEntity);
+            } catch (LinkageError | RuntimeException ignored) {
+                // The host removal below is still safe and necessary.
+            }
+            try {
+                if (!baseEntity.isDead()) {
+                    baseEntity.remove();
+                }
+            } catch (RuntimeException ignored) {
+                // A host that was already removed needs no further action.
+            }
+        }
+    }
+
+    private void warn(String message) {
+        logger().warning(message + " Falling back to a vanilla courier.");
+    }
+
+    private java.util.logging.Logger logger() {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        return plugin == null ? java.util.logging.Logger.getLogger("CourierPrime") : plugin.getLogger();
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/integration/MythicMobsProvider.java
+++ b/src/main/java/com/joaorihan/courierprime/integration/MythicMobsProvider.java
@@ -1,6 +1,7 @@
 package com.joaorihan.courierprime.integration;
 
 import com.joaorihan.courierprime.CourierPrime;
+import com.joaorihan.courierprime.courier.CourierType;
 import io.lumine.mythic.api.MythicProvider;
 import io.lumine.mythic.api.mobs.MythicMob;
 import io.lumine.mythic.bukkit.BukkitAdapter;
@@ -25,31 +26,46 @@ public class MythicMobsProvider implements CustomEntityProvider {
 
     @Override
     public boolean isAvailable() {
-        return Bukkit.getPluginManager().isPluginEnabled(PLUGIN_NAME);
+        return Bukkit.getPluginManager() != null
+                && Bukkit.getPluginManager().isPluginEnabled(PLUGIN_NAME);
     }
 
+    @Override
     public boolean hasEntity(String entityId) {
-        if (!isAvailable()) {
+        if (!isAvailable() || !CourierType.isValidCustomIdentifier(entityId)) {
             return false;
         }
 
         try {
-            return MythicProvider.get().getMobManager().getMythicMob(entityId).isPresent();
-        } catch (Exception e) {
+            if (MythicProvider.get() == null || MythicProvider.get().getMobManager() == null) {
+                return false;
+            }
+            Optional<MythicMob> mythicMob = MythicProvider.get().getMobManager().getMythicMob(entityId);
+            return mythicMob != null && mythicMob.isPresent();
+        } catch (LinkageError e) {
+            logger().log(Level.WARNING, "MythicMobs API could not validate courier mob '" + entityId + "'.", e);
+            return false;
+        } catch (RuntimeException e) {
+            logger().log(Level.WARNING, "MythicMobs could not validate courier mob '" + entityId + "'.", e);
             return false;
         }
     }
 
     @Override
     public Entity spawnEntity(String entityId, Location location) {
-        if (!isAvailable()) {
+        if (!isAvailable() || location == null || location.getWorld() == null
+                || !CourierType.isValidCustomIdentifier(entityId)) {
             return null;
         }
 
         try {
+            if (MythicProvider.get() == null || MythicProvider.get().getMobManager() == null) {
+                return null;
+            }
+
             Optional<MythicMob> mythicMob = MythicProvider.get().getMobManager().getMythicMob(entityId);
             
-            if (mythicMob.isEmpty()) {
+            if (mythicMob == null || mythicMob.isEmpty()) {
                 CourierPrime.getPlugin().getLogger().warning(
                     "MythicMob '" + entityId + "' not found! Falling back to vanilla entity."
                 );
@@ -57,12 +73,23 @@ public class MythicMobsProvider implements CustomEntityProvider {
             }
 
             var activeMob = mythicMob.get().spawn(BukkitAdapter.adapt(location), 1);
+            if (activeMob == null || activeMob.getEntity() == null) {
+                return null;
+            }
             return activeMob.getEntity().getBukkitEntity();
             
+        } catch (LinkageError e) {
+            logger().log(Level.WARNING, "MythicMobs API could not spawn courier mob '" + entityId + "'.", e);
+            return null;
         } catch (Exception e) {
             CourierPrime.getPlugin().getLogger().log(Level.WARNING, 
                 "Failed to spawn MythicMob '" + entityId + "': " + e.getMessage(), e);
             return null;
         }
+    }
+
+    private java.util.logging.Logger logger() {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        return plugin == null ? java.util.logging.Logger.getLogger("CourierPrime") : plugin.getLogger();
     }
 }

--- a/src/main/java/com/joaorihan/courierprime/listener/LetterListener.java
+++ b/src/main/java/com/joaorihan/courierprime/listener/LetterListener.java
@@ -1,6 +1,7 @@
 package com.joaorihan.courierprime.listener;
 
 import com.joaorihan.courierprime.CourierPrime;
+import com.joaorihan.courierprime.courier.Courier;
 import com.joaorihan.courierprime.courier.CourierManager;
 import org.bukkit.*;
 import org.bukkit.entity.Entity;
@@ -8,6 +9,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.VillagerCareerChangeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+import java.util.logging.Level;
 
 /**
  * Listens to letter related events
@@ -30,20 +33,42 @@ public class LetterListener implements Listener {
     @EventHandler
     public void onEntityInteract(PlayerInteractEntityEvent e) {
         Entity en = e.getRightClicked();
-        if (CourierManager.getActiveCouriers().containsKey(en)) {
-            if (CourierManager.getActiveCouriers().get(en).getRecipient().equals(e.getPlayer())
-                    && !CourierManager.getActiveCouriers().get(en).isDelivered()) {
-                CourierManager.getActiveCouriers().get(en).setDelivered();
-                e.setCancelled(true);
-                plugin.getLetterManager().getLetterSender().receive(e.getPlayer());
-                en.getWorld().playSound(en.getLocation(), Sound.BLOCK_WOOL_BREAK, 1, 1);
-                en.getWorld().spawnParticle(Particle.HAPPY_VILLAGER,
-                        en.getLocation().add(0, en.getHeight() / 2, 0), 20,
-                        en.getWidth() / 2, en.getHeight() / 2, en.getWidth() / 2);
-            } else if (!CourierManager.getActiveCouriers().get(en).getRecipient().equals(e.getPlayer())) {
-                e.setCancelled(true);
-                en.getWorld().playSound(en.getLocation(), Sound.UI_TOAST_OUT, 1, 1);
-            } else if (CourierManager.getActiveCouriers().get(en).isDelivered()) e.setCancelled(true);
+        Courier courier = CourierManager.getActiveCouriers().get(en);
+        if (courier == null) {
+            return;
+        }
+
+        // Every configured Bukkit Entity kind is a courier interaction target;
+        // no LivingEntity cast is needed for delivery.
+        e.setCancelled(true);
+        if (!courier.getRecipient().getUniqueId().equals(e.getPlayer().getUniqueId())) {
+            en.getWorld().playSound(en.getLocation(), Sound.UI_TOAST_OUT, 1, 1);
+            return;
+        }
+        if (courier.isDelivered()) {
+            return;
+        }
+
+        if (!courier.beginDelivery()) {
+            return;
+        }
+
+        boolean delivered = false;
+        try {
+            plugin.getLetterManager().getLetterSender().receive(e.getPlayer());
+        } catch (RuntimeException ex) {
+            plugin.getLogger().log(Level.WARNING,
+                    "Courier delivery failed for " + e.getPlayer().getName()
+                            + "; pending mail will remain retryable.", ex);
+        } finally {
+            delivered = courier.completeDeliveryAttempt();
+        }
+
+        if (delivered) {
+            en.getWorld().playSound(en.getLocation(), Sound.BLOCK_WOOL_BREAK, 1, 1);
+            en.getWorld().spawnParticle(Particle.HAPPY_VILLAGER,
+                    en.getLocation().add(0, en.getHeight() / 2, 0), 20,
+                    en.getWidth() / 2, en.getHeight() / 2, en.getWidth() / 2);
         }
     }
 

--- a/src/main/java/com/joaorihan/courierprime/listener/PlayerListener.java
+++ b/src/main/java/com/joaorihan/courierprime/listener/PlayerListener.java
@@ -12,7 +12,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Set;
 
@@ -35,14 +34,7 @@ public class PlayerListener implements Listener {
      */
     @EventHandler
     public void onJoin(PlayerJoinEvent e) {
-        Player player = e.getPlayer();
-
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                new Courier(player);
-            }
-        }.runTaskLater(CourierPrime.getPlugin(), MainConfig.getReceiveDelay());
+        scheduleCourier(e.getPlayer());
     }
 
     /**
@@ -51,17 +43,15 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onTeleport(PlayerTeleportEvent e) {
         Set<World> worlds = MainConfig.getBlockedWorlds();
+        if (e.getTo() == null) {
+            return;
+        }
         World to = e.getTo().getWorld();
         World from = e.getFrom().getWorld();
         Player recipient = e.getPlayer();
 
         if (worlds.contains(from) && !worlds.contains(to)) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    new Courier(recipient);
-                }
-            }.runTaskLater(CourierPrime.getPlugin(), MainConfig.getReceiveDelay());
+            scheduleCourier(recipient);
         }
     }
 
@@ -75,13 +65,24 @@ public class PlayerListener implements Listener {
         GameMode from = e.getPlayer().getGameMode();
         Player recipient = e.getPlayer();
         if (modes.contains(from) && !modes.contains(to)) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    new Courier(recipient);
-                }
-            }.runTaskLater(CourierPrime.getPlugin(), MainConfig.getReceiveDelay());
+            scheduleCourier(recipient);
         }
+    }
+
+    private void scheduleCourier(Player recipient) {
+        CourierPrime plugin = CourierPrime.getPlugin();
+        if (plugin == null || recipient == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (!recipient.isOnline() || plugin.getOutgoingManager() == null
+                    || plugin.getOutgoingManager().getOutgoing() == null
+                    || plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId()) == null
+                    || plugin.getOutgoingManager().getOutgoing().get(recipient.getUniqueId()).isEmpty()) {
+                return;
+            }
+            new Courier(recipient);
+        }, Math.max(0L, MainConfig.getReceiveDelay()));
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,7 +24,9 @@ letter:
   letter-custom-model-data: 0
   anon-letter-custom-model-data: 0
 
-# Courier types that players can select with /courier select
+# Courier types that players can select with /courier select.
+# /courier set is administrator-only, accepts any spawnable vanilla type, and
+# also accepts valid configured mm:/meg: values when their provider is present.
 # Supports three formats:
 #   - Vanilla EntityTypes: VILLAGER, COW, SHEEP, etc.
 #     (List: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html)


### PR DESCRIPTION
## Summary
- Harden courier type parsing, selection, offline-player assignment, and malformed couriers.yml loading.
- Keep optional MythicMobs and ModelEngine providers lazy, validated, and safely falling back to vanilla.
- Enforce courier lifecycle uniqueness, stale cleanup, non-living entity safety, and retry behavior.
- Complete mail transfer before marking a courier delivered; partial or failed transfers remain retryable.